### PR TITLE
feat: implement features page with navbar navigation

### DIFF
--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { CheckCircle2, Circle, Star, Zap, Shield, Palette } from 'lucide-react';
+
+export default function Features() {
+  const container = {
+    hidden: { opacity: 0 },
+    show: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+        delayChildren: 0.3,
+      },
+    },
+  };
+
+  const item = {
+    hidden: { y: 20, opacity: 0 },
+    show: { y: 0, opacity: 1, transition: { type: 'spring', stiffness: 300 } },
+  };
+
+  const features = [
+    {
+      icon: <Zap className="h-8 w-8 text-yellow-500" />,
+      title: "Lightning Fast",
+      description: "Built with Next.js 15 and React 19 for optimal performance",
+      status: "completed"
+    },
+    {
+      icon: <Palette className="h-8 w-8 text-blue-500" />,
+      title: "Modern Design System",
+      description: "Powered by shadcn/ui components and TailwindCSS",
+      status: "completed"
+    },
+    {
+      icon: <Shield className="h-8 w-8 text-green-500" />,
+      title: "Type Safety",
+      description: "Full TypeScript support with strict type checking",
+      status: "completed"
+    },
+    {
+      icon: <Star className="h-8 w-8 text-purple-500" />,
+      title: "Backend Integration",
+      description: "Postgres database with Drizzle ORM and Next.js APIs",
+      status: "planned"
+    },
+  ];
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <motion.div
+        className="text-center mb-12"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <motion.h1
+          className="text-4xl font-bold mb-4"
+          initial={{ y: -20 }}
+          animate={{ y: 0 }}
+          transition={{ type: 'spring', stiffness: 200 }}
+        >
+          Features
+        </motion.h1>
+        <motion.p
+          className="text-xl text-muted-foreground"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+        >
+          Discover what makes Kosuke Template special
+        </motion.p>
+      </motion.div>
+
+      <motion.div
+        className="grid md:grid-cols-2 gap-6"
+        variants={container}
+        initial="hidden"
+        animate="show"
+      >
+        {features.map((feature, index) => (
+          <motion.div
+            key={index}
+            className="border border-border rounded-lg p-6 bg-card hover:shadow-lg transition-shadow"
+            variants={item}
+            whileHover={{ y: -5 }}
+          >
+            <div className="flex items-start space-x-4">
+              <motion.div
+                whileHover={{ scale: 1.1 }}
+                transition={{ duration: 0.2 }}
+              >
+                {feature.icon}
+              </motion.div>
+              <div className="flex-1">
+                <div className="flex items-center space-x-2 mb-2">
+                  <h3 className="text-lg font-semibold">{feature.title}</h3>
+                  {feature.status === 'completed' ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <Circle className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </div>
+                <p className="text-muted-foreground">{feature.description}</p>
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </motion.div>
+
+      <motion.div
+        className="mt-12 text-center"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.8 }}
+      >
+        <motion.p
+          className="text-lg text-muted-foreground"
+          whileHover={{ scale: 1.05 }}
+        >
+          More features coming soon...
+        </motion.p>
+      </motion.div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
+import { Navbar } from '@/components/navbar';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -27,6 +28,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Navbar />
           {children}
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { CheckCircle2, Circle } from 'lucide-react';
 import { motion } from 'framer-motion';
 
@@ -22,28 +21,13 @@ export default function Home() {
   };
 
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <motion.main
-        className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start max-w-3xl mx-auto w-full"
+        className="flex flex-col gap-[32px] items-center sm:items-start max-w-3xl mx-auto w-full pt-8"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <motion.div
-          className="flex justify-between w-full items-center"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.2 }}
-        >
-          <motion.h2
-            className="text-xl font-bold"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            Kosuke Template
-          </motion.h2>
-          <ThemeToggle />
-        </motion.div>
 
         <motion.div
           className="text-center sm:text-left w-full"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { ThemeToggle } from '@/components/ui/theme-toggle';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+
+export function Navbar() {
+  return (
+    <motion.nav
+      className="w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      <div className="container flex h-16 items-center justify-between px-4">
+        <motion.div
+          className="flex items-center space-x-8"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+        >
+          <Link href="/" className="text-lg font-bold hover:text-primary transition-colors">
+            Kosuke Template
+          </Link>
+          <div className="hidden md:flex items-center space-x-6">
+            <Link 
+              href="/features" 
+              className="text-sm font-medium transition-colors hover:text-primary"
+            >
+              Features
+            </Link>
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.3 }}
+        >
+          <ThemeToggle />
+        </motion.div>
+      </div>
+    </motion.nav>
+  );
+}


### PR DESCRIPTION
This PR implements a placeholder features page accessible from the home navbar.

## Changes
- Add responsive navbar component with navigation menu
- Create features page showcasing current and planned features
- Update layout to include navbar across all pages
- Refactor home page to remove redundant header

Closes #26

Generated with [Claude Code](https://claude.ai/code)