### PR TITLE
Revert Markathon branding changes

### DIFF
--- a/app/(logged-out)/home/components/footer.tsx
+++ b/app/(logged-out)/home/components/footer.tsx
@@ -14,16 +14,7 @@ export default function Footer({ className }: FooterProps) {
     <footer className={cn('w-full mt-auto py-4 border-t', className)}>
       <div className="container flex flex-col items-center justify-between gap-4 md:flex-row">
         <p className="text-sm text-muted-foreground">
-          © {new Date().getFullYear()} Markathon. All rights reserved. Made by{' '}
-          <Link
-            href="https://www.underdogsgroup.it/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors underline underline-offset-4"
-          >
-            Underdogs Group
-          </Link>
-          .
+          © {new Date().getFullYear()} Kosuke Template. All rights reserved.
         </p>
         <div className="flex items-center gap-4">
           <Link

--- a/app/(logged-out)/home/components/navbar.tsx
+++ b/app/(logged-out)/home/components/navbar.tsx
@@ -41,7 +41,7 @@ export default function Navbar({ variant = 'standard', className }: NavbarProps)
     >
       <div className="container flex h-10 items-center justify-between">
         <Link href="/" className="flex items-center gap-2 font-semibold">
-          <span className="text-xl font-bold">Markathon</span>
+          <span className="text-xl font-bold">Kosuke</span>
         </Link>
 
         {/* Desktop navigation */}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Markathon',
+  title: 'Kosuke Template',
   description: 'Modern Next.js template with Clerk authentication',
 };
 


### PR DESCRIPTION
This PR reverts commit 426e339 which changed the branding from 'Kosuke Template' to 'Markathon'. 

The revert restores:
- Footer copyright text back to 'Kosuke Template'  
- Navbar title back to 'Kosuke'
- Page title back to 'Kosuke Template'
- Removes the 'Made by Underdogs Group' link from footer

Todos:

- [ ] Change name of the application on Clerk
- [ ] Remove the domain on Vercel dashboard

Reverting commit: 426e33967de70cdd72fb32124c329ef98350633d