### PR TITLE
Fix code linting with ESLint

### DIFF
--- a/.github/workflows/shadcn.yml
+++ b/.github/workflows/shadcn.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Lint code with ESLint
         run: |
           echo "🔍 Linting code with ESLint..."
-          pnpm run lint -- --fix
+          pnpm run lint
 
       - name: Check for file changes
         id: check-changes


### PR DESCRIPTION
Remove `-- --fix` from the `pnpm run lint` command in the CI workflow to fix the `Invalid project directory` error.

The `--fix` flag was causing `next lint` to misinterpret it as a directory argument. This flag is also redundant in CI as a previous step handles formatting, and the lint step in CI should primarily validate for errors rather than fix them.

---
<a href="https://cursor.com/background-agent?bcId=bc-767c2ee8-a363-4b3a-8332-9f2c58041bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-767c2ee8-a363-4b3a-8332-9f2c58041bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

