### PR TITLE
Update shadcn components with permissions

### DIFF
--- a/.github/workflows/shadcn.yml
+++ b/.github/workflows/shadcn.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
+  workflows: write  # Required to update workflow files in PRs
 
 jobs:
   update-shadcn-components:


### PR DESCRIPTION
Add `workflows: write` permission to allow the `shadcn.yml` workflow to create PRs that modify workflow files.

The workflow was failing to push PRs that included changes to `.github/workflows/shadcn.yml` because the default `GITHUB_TOKEN` lacked the necessary `workflows` permission. This change grants the required permission.

---
<a href="https://cursor.com/background-agent?bcId=bc-83c69d09-ad76-430c-8c78-28cd4040beef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83c69d09-ad76-430c-8c78-28cd4040beef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

