### PR TITLE
Fix invalid GitHub workflow file

### DIFF
--- a/.github/workflows/shadcn.yml
+++ b/.github/workflows/shadcn.yml
@@ -17,7 +17,6 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
-  workflows: write  # Required to update workflow files in PRs
 
 jobs:
   update-shadcn-components:


### PR DESCRIPTION
Remove invalid `workflows: write` permission to fix workflow validation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b2a0ee5-666d-4c03-ba1f-cfb39694b1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b2a0ee5-666d-4c03-ba1f-cfb39694b1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

