### PR TITLE
Middleware refactoring

### DIFF
--- a/__tests__/hooks/use-auth-actions.test.tsx
+++ b/__tests__/hooks/use-auth-actions.test.tsx
@@ -4,10 +4,10 @@ import { createQueryWrapper } from '../setup/mocks';
 import { vi } from 'vitest';
 
 // Mock useRouter
-const mockReplace = vi.fn();
+const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
-    replace: mockReplace,
+    push: mockPush,
   }),
 }));
 
@@ -51,8 +51,8 @@ describe('useAuthActions', () => {
       result.current.handleSignOut();
     });
 
+    expect(mockPush).toHaveBeenCalledWith('/');
     expect(mockSignOut).toHaveBeenCalled();
-    expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: '/' });
   });
 
   it('should handle multiple handleSignOut calls', async () => {
@@ -66,6 +66,7 @@ describe('useAuthActions', () => {
       result.current.handleSignOut();
     });
 
+    expect(mockPush).toHaveBeenCalledTimes(2);
     expect(mockSignOut).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/hooks/use-auth-actions.test.tsx
+++ b/__tests__/hooks/use-auth-actions.test.tsx
@@ -52,7 +52,7 @@ describe('useAuthActions', () => {
     });
 
     expect(mockSignOut).toHaveBeenCalled();
-    expect(mockReplace).toHaveBeenCalledWith('/');
+    expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: '/' });
   });
 
   it('should handle multiple handleSignOut calls', async () => {
@@ -67,6 +67,5 @@ describe('useAuthActions', () => {
     });
 
     expect(mockSignOut).toHaveBeenCalledTimes(2);
-    expect(mockReplace).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/lib/auth/utils.test.ts
+++ b/__tests__/lib/auth/utils.test.ts
@@ -4,29 +4,21 @@ import {
   extractUserData,
   extractUserDataFromWebhook,
   hasUserChanges,
-  requireAuth,
-  getAuthUser,
   isValidEmail,
   getDisplayName,
   getUserEmail,
   createActivityLogData,
   isAuthenticated,
-  createSafeRedirectUrl,
 } from '@/lib/auth/utils';
 import { ClerkUserType, ClerkWebhookUser, AuthState } from '@/lib/types';
 import { ActivityType } from '@/lib/db/schema';
-import { auth } from '@clerk/nextjs/server';
-import { redirect } from 'next/navigation';
-import { vi, type Mock } from 'vitest';
+import { vi } from 'vitest';
 import { createClerkWebhookUser } from '../../setup/factories';
 import { EmailAddressJSON } from '@clerk/types';
 
 // Mock external dependencies
 vi.mock('@clerk/nextjs/server');
 vi.mock('next/navigation');
-
-const mockAuth = auth as unknown as Mock;
-const mockRedirect = redirect as unknown as Mock;
 
 const defaultEmailAddresses: EmailAddressJSON[] = [
   {
@@ -361,43 +353,6 @@ describe('Auth Utils', () => {
     });
   });
 
-  describe('requireAuth', () => {
-    it('should return user ID when authenticated', async () => {
-      mockAuth.mockResolvedValue({ userId: 'user_123' });
-
-      const userId = await requireAuth();
-
-      expect(userId).toBe('user_123');
-      expect(mockRedirect).not.toHaveBeenCalled();
-    });
-
-    it('should redirect when not authenticated', async () => {
-      mockAuth.mockResolvedValue({ userId: null });
-
-      await requireAuth();
-
-      expect(mockRedirect).toHaveBeenCalledWith('/sign-in');
-    });
-  });
-
-  describe('getAuthUser', () => {
-    it('should return user ID when authenticated', async () => {
-      mockAuth.mockResolvedValue({ userId: 'user_123' });
-
-      const userId = await getAuthUser();
-
-      expect(userId).toBe('user_123');
-    });
-
-    it('should return null when not authenticated', async () => {
-      mockAuth.mockResolvedValue({ userId: null });
-
-      const userId = await getAuthUser();
-
-      expect(userId).toBe(null);
-    });
-  });
-
   describe('isValidEmail', () => {
     it('should return true for valid email addresses', () => {
       const validEmails = [
@@ -620,38 +575,6 @@ describe('Auth Utils', () => {
       };
 
       expect(isAuthenticated(authState)).toBe(false);
-    });
-  });
-
-  describe('createSafeRedirectUrl', () => {
-    it('should create URL with redirect parameter', () => {
-      const result = createSafeRedirectUrl('https://example.com', '/dashboard');
-
-      expect(result).toBe('https://example.com/?redirect_url=%2Fdashboard');
-    });
-
-    it('should return base URL when no redirect path', () => {
-      const result = createSafeRedirectUrl('https://example.com');
-
-      expect(result).toBe('https://example.com/');
-    });
-
-    it('should ignore non-slash redirect paths', () => {
-      const result = createSafeRedirectUrl('https://example.com', 'dashboard');
-
-      expect(result).toBe('https://example.com/');
-    });
-
-    it('should return base URL when URL parsing fails', () => {
-      const result = createSafeRedirectUrl('invalid-url', '/dashboard');
-
-      expect(result).toBe('invalid-url');
-    });
-
-    it('should handle empty redirect path', () => {
-      const result = createSafeRedirectUrl('https://example.com', '');
-
-      expect(result).toBe('https://example.com/');
     });
   });
 });

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { baseMiddleware as middleware } from '../middleware';
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server');
+  return {
+    ...actual,
+    NextResponse: {
+      next: vi.fn(() => ({ type: 'next' })),
+      redirect: vi.fn((url: URL) => ({ type: 'redirect', url: url.toString() })),
+    },
+  };
+});
+
+vi.mock('@clerk/nextjs/server', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clerkMiddleware: (fn: any) => fn,
+  createRouteMatcher: (routes: string[]) => {
+    return (req: NextRequest) => {
+      const url = new URL(req.url);
+      return routes.some((route) => {
+        // Handle exact matches and wildcard patterns
+        if (route === url.pathname) return true;
+        if (route.includes('(.*)')) {
+          const baseRoute = route.replace('(.*)', '');
+          return url.pathname.startsWith(baseRoute);
+        }
+        return false;
+      });
+    };
+  },
+}));
+
+describe('middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeReq = (url: string) => new NextRequest(`http://localhost:3000${url}`);
+
+  it('allows public routes for unauthenticated users', async () => {
+    const mockAuth = vi.fn().mockResolvedValue({ isAuthenticated: false });
+    const res = await middleware(mockAuth, makeReq('/terms'));
+    expect(res).toEqual({ type: 'next' });
+  });
+
+  it('redirects unauthenticated users on protected routes', async () => {
+    const redirectToSignIn = vi.fn(({ returnBackUrl }) => ({
+      type: 'redirect',
+      url: `${returnBackUrl}/sign-in`,
+    }));
+
+    const mockAuth = vi.fn().mockResolvedValue({
+      isAuthenticated: false,
+      redirectToSignIn,
+    });
+
+    const res = await middleware(mockAuth, makeReq('/dashboard'));
+    expect(redirectToSignIn).toHaveBeenCalled();
+    expect(res?.type).toBe('redirect');
+    expect(res?.url).toContain('/sign-in');
+  });
+
+  it('redirects authenticated users without onboarding', async () => {
+    const mockAuth = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      sessionClaims: { publicMetadata: { onboardingComplete: false } },
+    });
+
+    const res = await middleware(mockAuth, makeReq('/dashboard'));
+    expect(res?.type).toBe('redirect');
+    expect(res?.url).toContain('/onboarding');
+  });
+
+  it('redirects authenticated users with onboarding to org dashboard', async () => {
+    const mockAuth = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      sessionClaims: { publicMetadata: { onboardingComplete: true } },
+      orgSlug: 'test-org',
+    });
+
+    const res = await middleware(mockAuth, makeReq('/'));
+    expect(res?.type).toBe('redirect');
+    expect(res?.url).toContain('/org/test-org/dashboard');
+  });
+
+  it('calls NextResponse.next() for API routes', async () => {
+    const mockAuth = vi.fn().mockResolvedValue({});
+    const res = await middleware(mockAuth, makeReq('/api/user'));
+    expect(res).toEqual({ type: 'next' });
+  });
+});

--- a/app/(logged-out)/onboarding/page.tsx
+++ b/app/(logged-out)/onboarding/page.tsx
@@ -32,7 +32,7 @@ type OrganizationFormValues = z.infer<typeof createOrgFormSchema>;
 
 export default function OnboardingPage() {
   const router = useRouter();
-  const { isLoaded } = useUser();
+  const { isLoaded, user } = useUser();
   const { createOrganization, isCreating } = useCreateOrganization();
   const { mutateAsync: updateUserPublicMetadata, isPending } =
     trpc.user.updateUserPublicMetadata.useMutation();
@@ -50,6 +50,7 @@ export default function OnboardingPage() {
     createOrganization(data, {
       onSuccess: async (slug) => {
         await updateUserPublicMetadata({ publicMetadata: { onboardingComplete: true } });
+        await user?.reload(); // Reload user to refresh session with updated metadata
         router.push(`/org/${slug}/dashboard`);
       },
     });

--- a/app/(logged-out)/onboarding/page.tsx
+++ b/app/(logged-out)/onboarding/page.tsx
@@ -25,12 +25,14 @@ import {
 } from '@/components/ui/form';
 import { useCreateOrganization } from '@/hooks/use-create-organization';
 import { createOrgFormSchema } from '@/lib/trpc/schemas/organizations';
+import { trpc } from '@/lib/trpc/client';
 
 type OrganizationFormValues = z.infer<typeof createOrgFormSchema>;
 
 export default function OnboardingPage() {
   const { isLoaded } = useUser();
   const { createOrganization, isCreating } = useCreateOrganization();
+  const { mutate: updateUserPublicMetadata } = trpc.user.updateUserPublicMetadata.useMutation();
 
   const form = useForm<OrganizationFormValues>({
     resolver: zodResolver(createOrgFormSchema),
@@ -40,7 +42,9 @@ export default function OnboardingPage() {
   });
 
   const onSubmit = (data: OrganizationFormValues) => {
-    createOrganization(data);
+    createOrganization(data, {
+      onSuccess: () => updateUserPublicMetadata({ publicMetadata: { onboardingComplete: true } }),
+    });
   };
 
   if (!isLoaded) {

--- a/components/create-org-dialog.tsx
+++ b/components/create-org-dialog.tsx
@@ -36,10 +36,6 @@ type OrganizationFormValues = z.infer<typeof createOrgFormSchema>;
 interface CreateOrgDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /**
-   * Custom success handler. If provided, automatic redirect is disabled.
-   * Use this when you want to handle navigation differently (e.g., in sidebar switcher)
-   */
   onOrganizationCreated?: (slug: string) => void;
 }
 

--- a/components/create-org-dialog.tsx
+++ b/components/create-org-dialog.tsx
@@ -59,13 +59,10 @@ export function CreateOrgDialog({
 
   const onSubmit = (data: OrganizationFormValues) => {
     createOrganization(data, {
-      redirectAfterCreate: !onOrganizationCreated, // Disable redirect if custom handler provided
       onSuccess: (slug) => {
-        // Close dialog and reset form
         onOpenChange(false);
         form.reset();
 
-        // Call custom handler if provided
         onOrganizationCreated?.(slug);
       },
     });

--- a/components/sidebar-org-switcher.tsx
+++ b/components/sidebar-org-switcher.tsx
@@ -34,7 +34,7 @@ import { CreateOrgDialog } from '@/components/create-org-dialog';
 export function SidebarOrgSwitcher() {
   const router = useRouter();
   const { isMobile } = useSidebar();
-  const { organizations, isLoading, refetch } = useOrganizations();
+  const { organizations, isLoading } = useOrganizations();
   const {
     activeOrganization,
     switchOrganization,
@@ -44,11 +44,6 @@ export function SidebarOrgSwitcher() {
 
   // Handle organization creation from sidebar
   const handleOrganizationCreated = async (slug: string) => {
-    // Wait for organizations list to be refreshed
-    await refetch();
-
-    // Redirect to the new organization's dashboard
-    // (setActive is called by useCreateOrganization)
     router.push(`/org/${slug}/dashboard`);
   };
 

--- a/components/sidebar-org-switcher.tsx
+++ b/components/sidebar-org-switcher.tsx
@@ -8,7 +8,6 @@
 import * as React from 'react';
 import { ChevronsUpDown, Plus, Settings } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -30,20 +29,16 @@ import { useOrganizations } from '@/hooks/use-organizations';
 import { getInitials } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateOrgDialog } from '@/components/create-org-dialog';
+import { useRouter } from 'next/navigation';
 
 export function SidebarOrgSwitcher() {
   const router = useRouter();
   const { isMobile } = useSidebar();
   const { organizations, isLoading } = useOrganizations();
-  const {
-    activeOrganization,
-    switchOrganization,
-    isLoading: isActivating,
-  } = useActiveOrganization();
+  const { activeOrganization, isLoading: isActivating } = useActiveOrganization();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = React.useState(false);
 
-  // Handle organization creation from sidebar
-  const handleOrganizationCreated = async (slug: string) => {
+  const handleOrganizationCreated = (slug: string) => {
     router.push(`/org/${slug}/dashboard`);
   };
 
@@ -106,26 +101,27 @@ export function SidebarOrgSwitcher() {
               const isActive = org.id === activeOrganization.id;
 
               return (
-                <DropdownMenuItem
-                  key={org.id}
-                  onClick={() => switchOrganization(org.id)}
-                  className="gap-2 p-2 cursor-pointer"
-                >
-                  <Avatar className="h-6 w-6 rounded-md">
-                    {org.logoUrl && <AvatarImage src={org.logoUrl} alt={org.name} />}
-                    <AvatarFallback className="rounded-md bg-primary text-primary-foreground text-xs">
-                      {orgInitials}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="flex-1">
-                    <div className="font-medium text-sm">{org.name}</div>
-                  </div>
-                  {isActive && (
-                    <div
-                      className="h-2 w-2 rounded-full bg-primary"
-                      aria-label="Active workspace"
-                    />
-                  )}
+                <DropdownMenuItem key={org.id} asChild>
+                  <Link
+                    href={`/org/${org.slug}/dashboard`}
+                    className="gap-2 p-2 cursor-pointer flex items-center"
+                  >
+                    <Avatar className="h-6 w-6 rounded-md">
+                      {org.logoUrl && <AvatarImage src={org.logoUrl} alt={org.name} />}
+                      <AvatarFallback className="rounded-md bg-primary text-primary-foreground text-xs">
+                        {orgInitials}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1">
+                      <div className="font-medium text-sm">{org.name}</div>
+                    </div>
+                    {isActive && (
+                      <div
+                        className="h-2 w-2 rounded-full bg-primary"
+                        aria-label="Active workspace"
+                      />
+                    )}
+                  </Link>
                 </DropdownMenuItem>
               );
             })}

--- a/components/sidebar-org-switcher.tsx
+++ b/components/sidebar-org-switcher.tsx
@@ -43,20 +43,13 @@ export function SidebarOrgSwitcher() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = React.useState(false);
 
   // Handle organization creation from sidebar
-  // We need to refetch orgs, update localStorage, and redirect to the new org's dashboard
   const handleOrganizationCreated = async (slug: string) => {
     // Wait for organizations list to be refreshed
-    const result = await refetch();
+    await refetch();
 
-    // Find the new org by slug from the refetched data
-    const newOrg = result.data?.find((org) => org.slug === slug);
-    if (newOrg) {
-      // Update localStorage to set the new org as active
-      localStorage.setItem('activeOrganizationId', newOrg.id);
-
-      // Redirect to the new organization's dashboard
-      router.push(`/org/${newOrg.slug}/dashboard`);
-    }
+    // Redirect to the new organization's dashboard
+    // (setActive is called by useCreateOrganization)
+    router.push(`/org/${slug}/dashboard`);
   };
 
   // Loading state

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  { ignores: ['.next/**', 'node_modules/**', 'coverage/**'] },
+  { ignores: ['.next/**', 'node_modules/**', 'coverage/**', 'next-env.d.ts'] },
   ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier'),
   {
     rules: {

--- a/hooks/use-auth-actions.ts
+++ b/hooks/use-auth-actions.ts
@@ -2,20 +2,17 @@
 
 import { useMutation } from '@tanstack/react-query';
 import { useClerk } from '@clerk/nextjs';
-import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
 
 export function useAuthActions() {
   const { signOut } = useClerk();
-  const router = useRouter();
   const { toast } = useToast();
 
   const signOutMutation = useMutation({
-    mutationFn: async () => {
-      await signOut();
-    },
-    onSuccess: () => {
-      router.replace('/');
+    mutationFn: () => {
+      // Sign out and redirect to home page
+      // Clerk automatically clears entire session including orgSlug
+      return signOut({ redirectUrl: '/' });
     },
     onError: (error) => {
       console.error('Error signing out:', error);

--- a/hooks/use-auth-actions.ts
+++ b/hooks/use-auth-actions.ts
@@ -2,17 +2,18 @@
 
 import { useMutation } from '@tanstack/react-query';
 import { useClerk } from '@clerk/nextjs';
+import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
 
 export function useAuthActions() {
   const { signOut } = useClerk();
+  const router = useRouter();
   const { toast } = useToast();
 
   const signOutMutation = useMutation({
-    mutationFn: () => {
-      // Sign out and redirect to home page
-      // Clerk automatically clears entire session including orgSlug
-      return signOut({ redirectUrl: '/' });
+    mutationFn: async () => {
+      router.push('/');
+      await signOut();
     },
     onError: (error) => {
       console.error('Error signing out:', error);

--- a/hooks/use-create-organization.ts
+++ b/hooks/use-create-organization.ts
@@ -39,16 +39,14 @@ export function useCreateOrganization() {
     },
   });
 
-  const handleCreateOrganization = async (
+  const handleCreateOrganization = (
     data: { name: string },
     options?: CreateOrganizationOptions
   ) => {
-    try {
-      const result = await mutation.mutateAsync(data);
-      options?.onSuccess?.(result.slug);
-    } catch (error) {
-      options?.onError?.(error);
-    }
+    mutation.mutate(data, {
+      onSuccess: (result) => options?.onSuccess?.(result.slug),
+      onError: (error) => options?.onError?.(error),
+    });
   };
 
   return {

--- a/hooks/use-create-organization.ts
+++ b/hooks/use-create-organization.ts
@@ -7,6 +7,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useOrganizationList } from '@clerk/nextjs';
 import { useOrganizations } from '@/hooks/use-organizations';
 import { useToast } from '@/hooks/use-toast';
 
@@ -19,6 +20,7 @@ interface CreateOrganizationOptions {
 export function useCreateOrganization() {
   const router = useRouter();
   const { toast } = useToast();
+  const { setActive } = useOrganizationList();
   const { createOrganizationAsync } = useOrganizations();
   const [isCreating, setIsCreating] = useState(false);
 
@@ -32,6 +34,9 @@ export function useCreateOrganization() {
       const result = await createOrganizationAsync({
         name: data.name,
       });
+
+      // Set the new org as active in Clerk session
+      setActive?.({ organization: result.slug });
 
       toast({
         title: 'Success!',

--- a/hooks/use-organizations.ts
+++ b/hooks/use-organizations.ts
@@ -13,9 +13,6 @@ type RouterOutput = inferRouterOutputs<AppRouter>;
 type Organization = RouterOutput['organizations']['getUserOrganizations'][number];
 
 export function useOrganizations() {
-  const utils = trpc.useUtils();
-
-  // Fetch user's organizations
   const {
     data: organizations,
     isLoading,
@@ -26,23 +23,11 @@ export function useOrganizations() {
     retry: 1,
   });
 
-  // Create organization mutation
-  const createOrganization = trpc.organizations.createOrganization.useMutation({
-    onSuccess: async () => {
-      // Refetch organizations list immediately to ensure new org appears in the sidebar
-      // Use refetch() instead of invalidate() to wait for completion
-      await utils.organizations.getUserOrganizations.refetch();
-    },
-  });
-
   return {
     organizations: organizations ?? [],
     isLoading,
     error,
     refetch,
-    createOrganization: createOrganization.mutate,
-    createOrganizationAsync: createOrganization.mutateAsync,
-    isCreating: createOrganization.isPending,
   };
 }
 

--- a/hooks/use-organizations.ts
+++ b/hooks/use-organizations.ts
@@ -5,6 +5,7 @@
 
 'use client';
 
+import { useAuth } from '@clerk/nextjs';
 import { trpc } from '@/lib/trpc/client';
 import type { AppRouter } from '@/lib/trpc/router';
 import type { inferRouterOutputs } from '@trpc/server';
@@ -13,6 +14,8 @@ type RouterOutput = inferRouterOutputs<AppRouter>;
 type Organization = RouterOutput['organizations']['getUserOrganizations'][number];
 
 export function useOrganizations() {
+  const { isSignedIn } = useAuth();
+
   const {
     data: organizations,
     isLoading,
@@ -21,6 +24,7 @@ export function useOrganizations() {
   } = trpc.organizations.getUserOrganizations.useQuery(undefined, {
     staleTime: 1000 * 60 * 5, // 5 minutes
     retry: 1,
+    enabled: !!isSignedIn,
   });
 
   return {

--- a/lib/auth/constants.ts
+++ b/lib/auth/constants.ts
@@ -13,17 +13,6 @@ export const AUTH_ROUTES = {
   SETTINGS: '/settings',
 } as const;
 
-// Public Routes (routes that don't require authentication)
-export const PUBLIC_ROUTES = [
-  '/',
-  '/home',
-  '/sign-in(.*)',
-  '/sign-up(.*)',
-  '/api/billing/webhook',
-  '/api/clerk/webhook',
-  '/api/webhooks(.*)',
-] as const;
-
 // Error Messages
 export const AUTH_ERRORS = {
   USER_NOT_FOUND: 'User not found',
@@ -32,21 +21,4 @@ export const AUTH_ERRORS = {
   INVALID_WEBHOOK: 'Invalid webhook signature',
   MISSING_HEADERS: 'Missing required headers',
   CONFIGURATION_ERROR: 'Configuration error',
-} as const;
-
-// Activity Types for consistency
-export const ACTIVITY_TYPES = {
-  SIGN_UP: 'sign_up',
-  SIGN_IN: 'sign_in',
-  SIGN_OUT: 'sign_out',
-  UPDATE_ACCOUNT: 'update_account',
-  DELETE_ACCOUNT: 'delete_account',
-  PROFILE_IMAGE_UPDATED: 'profile_image_updated',
-} as const;
-
-// Email Templates
-export const EMAIL_SUBJECTS = {
-  WELCOME: 'Welcome to Kosuke Template! 🎉',
-  ACCOUNT_UPDATED: 'Your account has been updated',
-  ACCOUNT_DELETED: 'Your account has been deleted',
 } as const;

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -16,14 +16,11 @@ export {
   extractUserData,
   extractUserDataFromWebhook,
   hasUserChanges,
-  requireAuth,
-  getAuthUser,
   isValidEmail,
   getDisplayName,
   getUserEmail,
   createActivityLogData,
   isAuthenticated,
-  createSafeRedirectUrl,
 } from './utils';
 
 // Types - Re-export from centralized types
@@ -40,11 +37,4 @@ export type {
 export { ActivityType } from '@/lib/db/schema';
 
 // Constants
-export {
-  SYNC_INTERVALS,
-  AUTH_ROUTES,
-  PUBLIC_ROUTES,
-  AUTH_ERRORS,
-  ACTIVITY_TYPES,
-  EMAIL_SUBJECTS,
-} from './constants';
+export { SYNC_INTERVALS, AUTH_ROUTES, AUTH_ERRORS } from './constants';

--- a/lib/auth/utils.ts
+++ b/lib/auth/utils.ts
@@ -1,8 +1,6 @@
-import { auth } from '@clerk/nextjs/server';
-import { redirect } from 'next/navigation';
 import { ClerkUserType, ClerkWebhookUser, AuthState } from '@/lib/types';
 import { ActivityType } from '@/lib/db/schema';
-import { AUTH_ROUTES, SYNC_INTERVALS } from './constants';
+import { SYNC_INTERVALS } from './constants';
 
 /**
  * Check if user sync is stale (older than 24 hours)
@@ -79,27 +77,6 @@ export function hasUserChanges(
 }
 
 /**
- * Server-side auth guard that redirects unauthenticated users
- */
-export async function requireAuth() {
-  const { userId } = await auth();
-
-  if (!userId) {
-    redirect(AUTH_ROUTES.SIGN_IN);
-  }
-
-  return userId;
-}
-
-/**
- * Server-side auth check that returns user ID or null
- */
-export async function getAuthUser() {
-  const { userId } = await auth();
-  return userId;
-}
-
-/**
  * Validate email address format
  */
 export function isValidEmail(email: string): boolean {
@@ -164,19 +141,4 @@ export function isAuthenticated(authState: AuthState): authState is AuthState & 
   localUser: NonNullable<AuthState['localUser']>;
 } {
   return authState.isAuthenticated && authState.user !== null && authState.localUser !== null;
-}
-
-/**
- * Generate a safe redirect URL
- */
-export function createSafeRedirectUrl(baseUrl: string, redirectPath?: string): string {
-  try {
-    const url = new URL(baseUrl);
-    if (redirectPath && redirectPath.startsWith('/')) {
-      url.searchParams.set('redirect_url', redirectPath);
-    }
-    return url.toString();
-  } catch {
-    return baseUrl;
-  }
 }

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -55,12 +55,6 @@ export async function sendEmail({
   }
 }
 
-// Utility function to validate email address
-export function isValidEmail(email: string): boolean {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(email);
-}
-
 // Utility function to render React Email component to HTML for preview
 export async function renderEmailToHtml(component: React.ReactElement): Promise<string> {
   return await render(component);

--- a/lib/trpc/routers/user.ts
+++ b/lib/trpc/routers/user.ts
@@ -15,6 +15,7 @@ import {
   notificationSettingsSchema,
   uploadProfileImageSchema,
   updateDisplayNameSchema,
+  updateUserPublicMetadataSchema,
 } from '../schemas/user';
 
 export const userRouter = router({
@@ -172,6 +173,21 @@ export const userRouter = router({
         success: true,
         displayName: input.displayName,
         message: 'Display name updated successfully',
+      };
+    }),
+
+  updateUserPublicMetadata: protectedProcedure
+    .input(updateUserPublicMetadataSchema)
+    .mutation(async ({ input, ctx }) => {
+      const clerk = await clerkClient();
+      await clerk.users.updateUser(ctx.userId, input);
+
+      const updatedUser = await clerk.users.getUser(ctx.userId);
+      await syncUserFromClerk(updatedUser);
+
+      return {
+        success: true,
+        message: 'User public metadata updated successfully',
       };
     }),
 });

--- a/lib/trpc/schemas/user.ts
+++ b/lib/trpc/schemas/user.ts
@@ -21,3 +21,9 @@ export const uploadProfileImageSchema = z.object({
 export const updateDisplayNameSchema = z.object({
   displayName: z.string().min(1, 'Display name is required').max(100),
 });
+
+export const updateUserPublicMetadataSchema = z.object({
+  publicMetadata: z.object({
+    onboardingComplete: z.boolean().optional().default(false),
+  }),
+});

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -151,3 +151,12 @@ export interface ActionResult<T = unknown> {
   error?: string;
   message?: string;
 }
+
+// Custom Jwt Session Claims for Clerk
+declare global {
+  interface CustomJwtSessionClaims {
+    publicMetadata?: {
+      onboardingComplete?: boolean;
+    };
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 // Define public routes that don't require authentication
 const isPublicRoute = createRouteMatcher([
@@ -23,7 +23,8 @@ const isOnboardingRoute = createRouteMatcher(['/onboarding']);
 const isRootRoute = createRouteMatcher(['/']);
 const isApiRoute = createRouteMatcher(['/api(.*)']);
 
-export default clerkMiddleware(async (auth, req) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const baseMiddleware = async (auth: any, req: NextRequest) => {
   // API routes handle their own authentication via protectedProcedures
   if (isApiRoute(req)) return NextResponse.next();
 
@@ -56,8 +57,10 @@ export default clerkMiddleware(async (auth, req) => {
   }
 
   // Allow all other requests for authenticated users
-  if (isAuthenticated) return NextResponse.next();
-});
+  return NextResponse.next();
+};
+
+export default clerkMiddleware(baseMiddleware);
 
 export const config = {
   matcher: [


### PR DESCRIPTION
- Simplify useEffect in use-active-organization hook  
- Simplify middleware, keep it light (making requests there could eventually slow down the app)
- The redirect logic relies on publicMetadata?.onboardingComplete. In Clerk we need to include the publicMetadata in the session. See:
<img width="1242" height="584" alt="Screenshot 2025-10-13 at 09 24 56" src="https://github.com/user-attachments/assets/e93f9a41-e195-4856-83d6-b70f492a1723" />
