### PR TITLE
Remove blocking call

### DIFF
--- a/__tests__/lib/trpc/routers/billing.test.ts
+++ b/__tests__/lib/trpc/routers/billing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createCaller } from '@/lib/trpc/server';
-import { mockClerkUser } from '@/__tests__/setup/mocks';
-import type { UserSubscriptionInfo, SubscriptionEligibility, ClerkUserType } from '@/lib/types';
+import { createMockTRPCContext } from '@/__tests__/setup/mocks';
+import type { UserSubscriptionInfo, SubscriptionEligibility } from '@/lib/types';
 import { SubscriptionTier, SubscriptionStatus } from '@/lib/db/schema';
 import { SubscriptionState } from '@/lib/types';
 import type Stripe from 'stripe';
@@ -56,12 +56,7 @@ describe('Billing Router', () => {
       };
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.getStatus();
 
@@ -72,12 +67,7 @@ describe('Billing Router', () => {
     });
 
     it('should throw error when not authenticated', async () => {
-      const caller = await createCaller({
-        userId: null,
-        user: null,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext());
 
       await expect(caller.billing.getStatus()).rejects.toThrow('You must be logged in');
     });
@@ -105,12 +95,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.canSubscribe();
 
@@ -143,12 +128,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.canSubscribe();
 
@@ -180,12 +160,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.canSubscribe();
 
@@ -225,12 +200,7 @@ describe('Billing Router', () => {
         },
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.createCheckout({ tier: 'pro' });
 
@@ -265,12 +235,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.createCheckout({ tier: 'pro' })).rejects.toThrow(
         'Payment past due'
@@ -303,12 +268,7 @@ describe('Billing Router', () => {
         message: 'Stripe API error',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.createCheckout({ tier: 'pro' })).rejects.toThrow(
         'Stripe API error'
@@ -360,12 +320,7 @@ describe('Billing Router', () => {
         message: 'Subscription will be canceled at period end',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.cancel();
 
@@ -395,12 +350,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.cancel()).rejects.toThrow('Subscription cannot be canceled');
     });
@@ -444,12 +394,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.cancel()).rejects.toThrow('Subscription cannot be canceled');
     });
@@ -497,12 +442,7 @@ describe('Billing Router', () => {
         message: 'Stripe API error',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.cancel()).rejects.toThrow('Stripe API error');
     });
@@ -554,12 +494,7 @@ describe('Billing Router', () => {
         message: 'Subscription reactivated successfully',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.reactivate();
 
@@ -592,12 +527,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.reactivate()).rejects.toThrow(
         'Subscription cannot be reactivated'
@@ -625,12 +555,7 @@ describe('Billing Router', () => {
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
       vi.mocked(getSubscriptionEligibility).mockReturnValue(mockEligibility);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.reactivate()).rejects.toThrow('No subscription found');
     });
@@ -678,12 +603,7 @@ describe('Billing Router', () => {
         message: 'Stripe API error',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.reactivate()).rejects.toThrow('Stripe API error');
     });
@@ -701,12 +621,7 @@ describe('Billing Router', () => {
         },
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.createPortalSession();
 
@@ -722,12 +637,7 @@ describe('Billing Router', () => {
         message: 'No Stripe customer found',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.createPortalSession()).rejects.toThrow(
         'No Stripe customer found'
@@ -761,12 +671,7 @@ describe('Billing Router', () => {
         } as unknown as Stripe.Subscription,
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.sync({ action: 'user' });
 
@@ -785,12 +690,7 @@ describe('Billing Router', () => {
         errors: [],
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.sync({ action: 'stale' });
 
@@ -809,12 +709,7 @@ describe('Billing Router', () => {
         errors: [],
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.sync({ action: 'emergency' });
 
@@ -856,12 +751,7 @@ describe('Billing Router', () => {
 
       vi.mocked(getUserSubscription).mockResolvedValue(mockSubscriptionInfo);
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.getSyncStatus();
 
@@ -883,12 +773,7 @@ describe('Billing Router', () => {
         message: 'Pending downgrade has been canceled',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       const result = await caller.billing.cancelDowngrade();
 
@@ -905,12 +790,7 @@ describe('Billing Router', () => {
         message: 'No pending downgrade found',
       });
 
-      const caller = await createCaller({
-        userId: 'user_123',
-        user: mockClerkUser as ClerkUserType,
-        orgId: null,
-        orgRole: null,
-      });
+      const caller = await createCaller(createMockTRPCContext({ userId: 'user_123' }));
 
       await expect(caller.billing.cancelDowngrade()).rejects.toThrow('No pending downgrade found');
     });

--- a/__tests__/setup/mocks.ts
+++ b/__tests__/setup/mocks.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import React, { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Stripe from 'stripe';
+import { ClerkUserType } from '@/lib/types/user';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -302,5 +303,25 @@ export function createMockQueryClient() {
     getQueryDefaults: vi.fn(),
     setQueryDefaults: vi.fn(),
     getMutationDefaults: vi.fn(),
+  };
+}
+
+// Helper to create tRPC test context matching createTRPCContext signature
+export function createMockTRPCContext(options?: {
+  userId?: string | null;
+  orgId?: string | null;
+  orgRole?: string | null;
+  getUser?: () => Promise<ClerkUserType | null>;
+}) {
+  const userId = options?.userId ?? null;
+
+  return {
+    userId,
+    orgId: options?.orgId ?? null,
+    orgRole: options?.orgRole ?? null,
+    async getUser() {
+      return userId ? (mockClerkUserType as ClerkUserType) : null;
+    },
+    ...options,
   };
 }

--- a/engine/uv.lock
+++ b/engine/uv.lock
@@ -131,7 +131,7 @@ wheels = [
 
 [[package]]
 name = "engine-service"
-version = "1.3.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/hooks/use-tasks.ts
+++ b/hooks/use-tasks.ts
@@ -29,6 +29,7 @@ export function useTasks(filters?: TaskListFilters) {
   } = trpc.tasks.list.useQuery(filters, {
     staleTime: 1000 * 60 * 2, // 2 minutes
     placeholderData: (previousData) => previousData,
+    enabled: !!filters?.organizationId,
   });
 
   // Create task mutation


### PR DESCRIPTION
## What's Changed

Remove blocking call to get the user. For every request `await currentUser()` was called.

See results for fetching 5 tasks:

**Before**

<img width="718" height="247" alt="Screenshot 2025-10-21 at 14 14 02" src="https://github.com/user-attachments/assets/66b060e4-865a-457d-ad16-d5c1c42d9d1d" />
 
**After**

<img width="722" height="256" alt="Screenshot 2025-10-21 at 14 14 23" src="https://github.com/user-attachments/assets/5ed37487-c776-49fe-92f7-b55fa726ef6e" />

## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [x] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
