### PR TITLE
Fix useSearchParams for static pages

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -75,12 +75,14 @@ bun run shadcn:check    # Check for available component updates
 - **TypeScript**: Validates types across entire codebase
 - **Tests**: Ensures functionality works as expected
 - **Knip**: Ensures no duplicate or unusued code is pushed to production
+- **Build**: Ensure the application build is successful
 
 ```bash
 bun run lint      # Must pass with 0 errors
 bun run typecheck # Must pass with 0 errors
-bun run test          # All tests must pass
+bun run test      # All tests must pass
 bun run knip      # Must pass with 0 errors
+bun run build     # Must build successfully
 ```
 
 These checks run in pre-commit hooks and CI/CD. Fix all issues before marking work complete.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1427,6 +1427,184 @@ const query = useQuery<UserProfile, Error>({
 });
 ```
 
+
+### useSearchParams() Usage - MANDATORY
+
+**ALWAYS handle `useSearchParams()` properly to avoid static generation errors. Next.js requires Suspense boundaries for reactive search params, or use `location.search` for non-reactive access.**
+
+#### **The Problem**
+
+Using `useSearchParams()` in a page that's being statically generated causes build errors:
+
+```
+useSearchParams() should be wrapped in a suspense boundary at page "/terms"
+```
+
+#### **✅ WHEN TO USE location.search (Non-Reactive)**
+
+**Use `window.location.search` when query params are read-only and don't need to trigger re-renders:**
+
+- **One-time reads** - Reading query params for initial render only
+- **Static pages** - Public pages that are statically generated
+- **No reactivity needed** - Params don't change during component lifecycle
+- **Server-side compatible** - Works in both client and server components (with proper checks)
+
+```typescript
+// ✅ CORRECT - Use location.search for non-reactive access
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function TermsPage() {
+  const [queryParam, setQueryParam] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Read query params once on mount
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      setQueryParam(params.get('ref'));
+    }
+  }, []);
+
+  return <div>Referral: {queryParam}</div>;
+}
+
+// ✅ CORRECT - Server Component with searchParams prop
+export default function TermsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const params = await searchParams;
+  return <div>Referral: {params.ref}</div>;
+}
+```
+
+#### **✅ WHEN TO USE useSearchParams() with Suspense (Reactive)**
+
+**Use `useSearchParams()` wrapped in Suspense when query params need to be reactive:**
+
+- **Reactive updates** - Component needs to re-render when params change
+- **Dynamic filtering** - Search, pagination, or filtering based on URL params
+- **Real-time sync** - URL params sync with component state
+- **Client-side navigation** - Params change via Next.js router
+
+```typescript
+// ✅ CORRECT - Wrap useSearchParams() in Suspense
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+function SearchContent() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q') || '';
+
+  return <div>Search: {query}</div>;
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SearchContent />
+    </Suspense>
+  );
+}
+```
+
+#### **❌ WRONG - useSearchParams() without Suspense**
+
+```typescript
+// ❌ NO! This causes build errors on static pages
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+export default function TermsPage() {
+  const searchParams = useSearchParams(); // ❌ Missing Suspense boundary
+  const ref = searchParams.get('ref');
+
+  return <div>Referral: {ref}</div>;
+}
+```
+
+#### **🔧 Decision Tree**
+
+**Do query params need to trigger re-renders when they change?**
+
+- ✅ **NO** (read-only, one-time) → Use `window.location.search` or `searchParams` prop (Server Components)
+- ✅ **YES** (reactive, dynamic) → Use `useSearchParams()` wrapped in `<Suspense>`
+
+**Examples:**
+
+- Terms/Privacy pages (static) → `location.search` or `searchParams` prop
+- Search results (dynamic) → `useSearchParams()` with Suspense
+- Filter pages (reactive) → `useSearchParams()` with Suspense
+- Analytics tracking (one-time) → `location.search`
+
+#### **🏗️ Best Practices**
+
+**Server Components (Recommended for Static Pages):**
+
+```typescript
+// ✅ BEST - Server Component with searchParams prop (no Suspense needed)
+export default async function TermsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const params = await searchParams;
+  return <div>Referral: {params.ref || 'none'}</div>;
+}
+```
+
+**Client Components (Non-Reactive):**
+
+```typescript
+// ✅ GOOD - Client Component with location.search
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function TermsPage() {
+  const [ref, setRef] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      setRef(params.get('ref'));
+    }
+  }, []);
+
+  return <div>Referral: {ref || 'none'}</div>;
+}
+```
+
+**Client Components (Reactive):**
+
+```typescript
+// ✅ GOOD - Client Component with Suspense
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+function TermsContent() {
+  const searchParams = useSearchParams();
+  const ref = searchParams.get('ref');
+
+  return <div>Referral: {ref || 'none'}</div>;
+}
+
+export default function TermsPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <TermsContent />
+    </Suspense>
+  );
+}
+```
+
 ### tRPC Integration - Type-Safe API Layer
 
 **tRPC provides end-to-end type safety for API routes. Use it for ALL internal API endpoints.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,8 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
-        # Automatically reads from .bun-version file
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          bun-version-file: '.bun-version'
 
       - name: Cache Bun
         uses: actions/cache@v4
@@ -36,6 +32,9 @@ jobs:
 
       - name: Copy environment variables
         run: cp .env.example .env
+
+      - name: Start Docker services
+        run: docker compose up -d postgres
 
       - name: Run ESLint
         run: bun run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run Knip
         run: bun run knip
 
+      - name: Build application
+        run: bun run build
+
   test-engine:
     name: Test and Lint Engine Service
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,12 +70,14 @@ bun run shadcn:check    # Check for available component updates
 - **TypeScript**: Validates types across entire codebase
 - **Tests**: Ensures functionality works as expected
 - **Knip**: Ensures no duplicate or unusued code is pushed to production
+- **Build**: Ensure the application build is successful
 
 ```bash
 bun run lint      # Must pass with 0 errors
 bun run typecheck # Must pass with 0 errors
-bun run test          # All tests must pass
+bun run test      # All tests must pass
 bun run knip      # Must pass with 0 errors
+bun run build     # Must build successfully
 ```
 
 These checks run in pre-commit hooks and CI/CD. Fix all issues before marking work complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1422,6 +1422,207 @@ const query = useQuery<UserProfile, Error>({
 });
 ```
 
+### Next.js useSearchParams() Usage - MANDATORY
+
+**ALWAYS handle `useSearchParams()` properly to avoid static generation errors. Next.js requires Suspense boundaries for reactive search params, or use `location.search` for non-reactive access.**
+
+#### **The Problem**
+
+Using `useSearchParams()` in a page that's being statically generated causes build errors:
+
+```
+useSearchParams() should be wrapped in a suspense boundary at page "/terms"
+```
+
+#### **✅ WHEN TO USE location.search (Non-Reactive)**
+
+**Use `window.location.search` when query params are read-only and don't need to trigger re-renders:**
+
+- **One-time reads** - Reading query params for initial render only
+- **Static pages** - Public pages that are statically generated
+- **No reactivity needed** - Params don't change during component lifecycle
+- **Server-side compatible** - Works in both client and server components (with proper checks)
+
+```typescript
+// ✅ CORRECT - Use location.search for non-reactive access
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function TermsPage() {
+  const [queryParam, setQueryParam] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Read query params once on mount
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      setQueryParam(params.get('ref'));
+    }
+  }, []);
+
+  return <div>Referral: {queryParam}</div>;
+}
+
+// ✅ CORRECT - Server Component with searchParams prop
+export default function TermsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const params = await searchParams;
+  return <div>Referral: {params.ref}</div>;
+}
+```
+
+#### **✅ WHEN TO USE useSearchParams() with Suspense (Reactive)**
+
+**Use `useSearchParams()` wrapped in Suspense when query params need to be reactive:**
+
+- **Reactive updates** - Component needs to re-render when params change
+- **Dynamic filtering** - Search, pagination, or filtering based on URL params
+- **Real-time sync** - URL params sync with component state
+- **Client-side navigation** - Params change via Next.js router
+
+```typescript
+// ✅ CORRECT - Wrap useSearchParams() in Suspense
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+function SearchContent() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('q') || '';
+
+  return <div>Search: {query}</div>;
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SearchContent />
+    </Suspense>
+  );
+}
+```
+
+#### **❌ WRONG - useSearchParams() without Suspense**
+
+```typescript
+// ❌ NO! This causes build errors on static pages
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+export default function TermsPage() {
+  const searchParams = useSearchParams(); // ❌ Missing Suspense boundary
+  const ref = searchParams.get('ref');
+
+  return <div>Referral: {ref}</div>;
+}
+```
+
+#### **🔧 Decision Tree**
+
+**Do query params need to trigger re-renders when they change?**
+
+- ✅ **NO** (read-only, one-time) → Use `window.location.search` or `searchParams` prop (Server Components)
+- ✅ **YES** (reactive, dynamic) → Use `useSearchParams()` wrapped in `<Suspense>`
+
+**Examples:**
+
+- Terms/Privacy pages (static) → `location.search` or `searchParams` prop
+- Search results (dynamic) → `useSearchParams()` with Suspense
+- Filter pages (reactive) → `useSearchParams()` with Suspense
+- Analytics tracking (one-time) → `location.search`
+
+#### **🏗️ Best Practices**
+
+**Server Components (Recommended for Static Pages):**
+
+```typescript
+// ✅ BEST - Server Component with searchParams prop (no Suspense needed)
+export default async function TermsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const params = await searchParams;
+  return <div>Referral: {params.ref || 'none'}</div>;
+}
+```
+
+**Client Components (Non-Reactive):**
+
+```typescript
+// ✅ GOOD - Client Component with location.search
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function TermsPage() {
+  const [ref, setRef] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      setRef(params.get('ref'));
+    }
+  }, []);
+
+  return <div>Referral: {ref || 'none'}</div>;
+}
+```
+
+**Client Components (Reactive):**
+
+```typescript
+// ✅ GOOD - Client Component with Suspense
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+function TermsContent() {
+  const searchParams = useSearchParams();
+  const ref = searchParams.get('ref');
+
+  return <div>Referral: {ref || 'none'}</div>;
+}
+
+export default function TermsPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <TermsContent />
+    </Suspense>
+  );
+}
+```
+
+**Always choose the simplest solution that meets your requirements. Prefer Server Components with `searchParams` prop for static pages.**
+
+#### **Knip Guidelines - MANDATORY**
+
+When fixing Knip errors:
+
+- ✅ **ONLY fix unused exports and imports** - Remove or mark as used
+- ✅ **Fix unused internal code** - Remove dead functions, variables, types
+- ✅ **Fix duplicate exports** - Consolidate or remove duplicates
+- ❌ **NEVER modify package.json** - Ignore dependency-related warnings
+- ❌ **NEVER add or remove packages** - Only fix code-level issues
+- ❌ **NEVER update dependencies** - Leave package versions unchanged
+
+```bash
+# ✅ CORRECT - Fix unused exports
+export const usedFunction = () => {}; // Keep
+// Remove: export const unusedFunction = () => {}; // Delete this
+
+# ❌ WRONG - Don't touch dependencies
+// Don't remove packages from package.json based on Knip warnings
+// Don't update package versions
+// Ignore "unlisted dependencies" warnings
+```
+
 ### tRPC Integration - Type-Safe API Layer
 
 **tRPC provides end-to-end type safety for API routes. Use it for ALL internal API endpoints.**

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -10,7 +10,7 @@
 import { signOut, useSession, emailOtp, signIn } from '@/lib/auth/client';
 import { useMutation } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { trpc } from '@/lib/trpc/client';
 import { AUTH_ROUTES } from '@/lib/auth/constants';
 
@@ -65,13 +65,16 @@ export function useAuthActions() {
   const { toast } = useToast();
   const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { refetch, isRefetching } = useSession();
 
   const clearSignInAttemptMutation = trpc.auth.clearSignInAttempt.useMutation();
 
   const isSignUpFlow = pathname?.includes('/sign-up');
-  const redirectUrl = searchParams?.get('redirect');
+  let redirectUrl: string | null = null;
+
+  if (typeof window !== 'undefined') {
+    redirectUrl = new URLSearchParams(window.location.search).get('redirect');
+  }
 
   const verifyOTPMutation = useMutation({
     mutationFn: async ({ email, otp }: { email: string; otp: string }) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     include: ['__tests__/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['**/node_modules/**', '**/.next/**', '__tests__/setup/**', '**/engine/**'],
     unstubEnvs: true,
+    unstubGlobals: true,
     coverage: {
       provider: 'v8', // Faster than istanbul
       include: [


### PR DESCRIPTION
## What's Changed

Avoid using useSearchParams as it breaks static pages. Use window object instead (no need for query params to be reactive in this case)

## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [ ] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
