### PR TITLE
Fix redirect after invitation

### DIFF
--- a/__tests__/api/accept-invitation/[invitationId]/route.test.ts
+++ b/__tests__/api/accept-invitation/[invitationId]/route.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/accept-invitation/[invitationId]/route';
+
+// Mock auth
+vi.mock('@/lib/auth/providers', () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+      acceptInvitation: vi.fn(),
+      setActiveOrganization: vi.fn(),
+    },
+  },
+}));
+
+// Mock organizations
+vi.mock('@/lib/organizations', () => ({
+  getOrgById: vi.fn(),
+}));
+
+// Mock next/headers
+vi.mock('next/headers', () => ({
+  headers: vi.fn(() => Promise.resolve({})),
+}));
+
+describe('Accept Invitation Route', () => {
+  let auth: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let getOrgById: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  const mockInvitationId = 'inv_123';
+  const mockOrgId = 'org_123';
+  const mockOrgSlug = 'test-org';
+  const mockBaseUrl = 'https://example.com';
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', mockBaseUrl);
+
+    // Dynamically import after mocks are applied
+    ({ auth } = await import('@/lib/auth/providers'));
+    ({ getOrgById } = await import('@/lib/organizations'));
+  });
+
+  describe('GET /api/accept-invitation/[invitationId]', () => {
+    it('should redirect to sign-in if user is not authenticated', async () => {
+      auth.api.getSession.mockResolvedValue(null);
+
+      const request = new NextRequest(`${mockBaseUrl}/api/accept-invitation/${mockInvitationId}`);
+      const response = await GET(request, {
+        params: Promise.resolve({ invitationId: mockInvitationId }),
+      });
+
+      expect(response.status).toBe(307); // Redirect status
+      expect(response.headers.get('location')).toBe(
+        `${mockBaseUrl}/sign-in?redirect=%2Fapi%2Faccept-invitation%2F${mockInvitationId}`
+      );
+      expect(auth.api.acceptInvitation).not.toHaveBeenCalled();
+    });
+
+    it('should accept invitation and redirect to root when authenticated', async () => {
+      auth.api.getSession.mockResolvedValue({
+        user: { id: 'user_123', email: 'test@example.com' },
+      });
+      auth.api.acceptInvitation.mockResolvedValue({
+        invitation: { organizationId: null },
+      });
+
+      const request = new NextRequest(`${mockBaseUrl}/api/accept-invitation/${mockInvitationId}`);
+      const response = await GET(request, {
+        params: Promise.resolve({ invitationId: mockInvitationId }),
+      });
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(`${mockBaseUrl}/`);
+      expect(auth.api.acceptInvitation).toHaveBeenCalledWith({
+        body: { invitationId: mockInvitationId },
+        headers: {},
+      });
+      expect(auth.api.setActiveOrganization).not.toHaveBeenCalled();
+    });
+
+    it('should set active organization when invitation includes organizationId', async () => {
+      auth.api.getSession.mockResolvedValue({
+        user: { id: 'user_123', email: 'test@example.com' },
+      });
+      auth.api.acceptInvitation.mockResolvedValue({
+        invitation: { organizationId: mockOrgId },
+      });
+      getOrgById.mockResolvedValue({ id: mockOrgId, slug: mockOrgSlug });
+      auth.api.setActiveOrganization.mockResolvedValue({});
+
+      const request = new NextRequest(`${mockBaseUrl}/api/accept-invitation/${mockInvitationId}`);
+      const response = await GET(request, {
+        params: Promise.resolve({ invitationId: mockInvitationId }),
+      });
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(`${mockBaseUrl}/`);
+      expect(auth.api.acceptInvitation).toHaveBeenCalledWith({
+        body: { invitationId: mockInvitationId },
+        headers: {},
+      });
+      expect(getOrgById).toHaveBeenCalledWith(mockOrgId);
+      expect(auth.api.setActiveOrganization).toHaveBeenCalledWith({
+        body: {
+          organizationId: mockOrgId,
+          organizationSlug: mockOrgSlug,
+        },
+        headers: {},
+      });
+    });
+
+    it('should handle missing organization slug gracefully', async () => {
+      auth.api.getSession.mockResolvedValue({
+        user: { id: 'user_123', email: 'test@example.com' },
+      });
+      auth.api.acceptInvitation.mockResolvedValue({
+        invitation: { organizationId: mockOrgId },
+      });
+      getOrgById.mockResolvedValue(null); // Organization not found
+      auth.api.setActiveOrganization.mockResolvedValue({});
+
+      const request = new NextRequest(`${mockBaseUrl}/api/accept-invitation/${mockInvitationId}`);
+      const response = await GET(request, {
+        params: Promise.resolve({ invitationId: mockInvitationId }),
+      });
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(`${mockBaseUrl}/`);
+      expect(auth.api.setActiveOrganization).toHaveBeenCalledWith({
+        body: {
+          organizationId: mockOrgId,
+          organizationSlug: undefined,
+        },
+        headers: {},
+      });
+    });
+
+    it('should redirect to root on error', async () => {
+      auth.api.getSession.mockResolvedValue({
+        user: { id: 'user_123', email: 'test@example.com' },
+      });
+      auth.api.acceptInvitation.mockRejectedValue(new Error('Invitation not found'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const request = new NextRequest(`${mockBaseUrl}/api/accept-invitation/${mockInvitationId}`);
+      const response = await GET(request, {
+        params: Promise.resolve({ invitationId: mockInvitationId }),
+      });
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(`${mockBaseUrl}/`);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should use NEXT_PUBLIC_APP_URL for redirect URLs', async () => {
+      const customBaseUrl = 'https://production.example.com';
+      vi.stubEnv('NEXT_PUBLIC_APP_URL', customBaseUrl);
+
+      auth.api.getSession.mockResolvedValue({
+        user: { id: 'user_123', email: 'test@example.com' },
+      });
+      auth.api.acceptInvitation.mockResolvedValue({
+        invitation: { organizationId: null },
+      });
+
+      const request = new NextRequest(`${mockBaseUrl}/api/accept-invitation/${mockInvitationId}`);
+      const response = await GET(request, {
+        params: Promise.resolve({ invitationId: mockInvitationId }),
+      });
+
+      expect(response.headers.get('location')).toBe(`${customBaseUrl}/`);
+    });
+  });
+});

--- a/app/api/accept-invitation/[invitationId]/route.ts
+++ b/app/api/accept-invitation/[invitationId]/route.ts
@@ -9,6 +9,8 @@ export async function GET(
 ) {
   const { invitationId } = await params;
 
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL;
+
   try {
     const session = await auth.api.getSession({
       headers: await headers(),
@@ -16,7 +18,7 @@ export async function GET(
 
     if (!session?.user) {
       // Not signed in, redirect to sign-in and preserve this API URL as redirect target
-      const signInUrl = new URL('/sign-in', request.url);
+      const signInUrl = new URL('/sign-in', baseUrl);
       signInUrl.searchParams.set('redirect', request.nextUrl.pathname);
       return NextResponse.redirect(signInUrl);
     }
@@ -43,9 +45,9 @@ export async function GET(
     }
 
     // Redirect to root – middleware will route to active org dashboard if available
-    return NextResponse.redirect(new URL('/', request.url));
+    return NextResponse.redirect(new URL('/', baseUrl));
   } catch (error) {
     console.error(error);
-    return NextResponse.redirect(new URL('/', request.url));
+    return NextResponse.redirect(new URL('/', baseUrl));
   }
 }


### PR DESCRIPTION
## What's Changed

After accept invitation redirects to internal address. Set base url to be NEXT_PUBLIC_APP_URL


## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [ ] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
