### PR TITLE
Add delete organisation feature

### DIFF
--- a/__tests__/hooks/use-delete-organization.test.tsx
+++ b/__tests__/hooks/use-delete-organization.test.tsx
@@ -1,0 +1,129 @@
+import { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { type Mock, vi } from 'vitest';
+
+import { AUTH_ROUTES } from '@/lib/auth/constants';
+import { trpc } from '@/lib/trpc/client';
+
+import { useDeleteOrganization } from '@/hooks/use-delete-organization';
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+const mockInvalidateUserOrgs = vi.fn();
+const mockInvalidateOrg = vi.fn();
+
+vi.mock('@/lib/trpc/client', () => ({
+  trpc: {
+    organizations: {
+      deleteOrganization: {
+        useMutation: vi.fn(
+          (_: {
+            onSuccess?: (data: { message: string }) => void;
+            onError?: (error: { message: string }) => void;
+          }) => ({
+            mutate: vi.fn(),
+            isPending: false,
+          })
+        ),
+      },
+    },
+    useUtils: () => ({
+      organizations: {
+        getUserOrganizations: {
+          invalidate: mockInvalidateUserOrgs,
+        },
+        getOrganization: {
+          invalidate: mockInvalidateOrg,
+        },
+      },
+    }),
+  },
+}));
+
+describe('useDeleteOrganization', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    // Reset global location
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = {
+      href: '',
+    };
+
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it('should call toast, invalidate queries, and redirect on successful deletion', () => {
+    vi.useFakeTimers();
+
+    (trpc.organizations.deleteOrganization.useMutation as Mock).mockReturnValue({
+      mutate: () => {
+        const options = (trpc.organizations.deleteOrganization.useMutation as Mock).mock
+          .calls[0][0];
+        options.onSuccess({ message: 'Organization deleted successfully' });
+      },
+      isPending: false,
+    });
+
+    const { result } = renderHook(() => useDeleteOrganization(), { wrapper });
+
+    result.current.deleteOrganization({ organizationId: 'org_123' });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Success',
+      description: 'Organization deleted successfully',
+    });
+
+    expect(mockInvalidateUserOrgs).toHaveBeenCalled();
+    expect(mockInvalidateOrg).toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+    expect(window.location.href).toBe(AUTH_ROUTES.ROOT);
+
+    vi.useRealTimers();
+  });
+
+  it('should show destructive toast on deletion error', () => {
+    (trpc.organizations.deleteOrganization.useMutation as Mock).mockReturnValue({
+      mutate: () => {
+        const options = (trpc.organizations.deleteOrganization.useMutation as Mock).mock
+          .calls[0][0];
+        options.onError(new Error('Failed to delete organization'));
+      },
+      isPending: false,
+    });
+
+    const { result } = renderHook(() => useDeleteOrganization(), { wrapper });
+
+    result.current.deleteOrganization({ organizationId: 'org_123' });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Error',
+      description: 'Failed to delete organization',
+      variant: 'destructive',
+    });
+
+    expect(mockInvalidateUserOrgs).not.toHaveBeenCalled();
+    expect(mockInvalidateOrg).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/organizations/utils.test.ts
+++ b/__tests__/lib/organizations/utils.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { switchToNextOrganization } from '@/lib/organizations/utils';
+
+vi.mock('@/lib/auth/providers', () => ({
+  auth: {
+    api: {
+      listOrganizations: vi.fn(),
+      setActiveOrganization: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(() => Promise.resolve({})),
+}));
+
+describe('switchToNextOrganization', () => {
+  let auth: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const mockHeaders = {};
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Dynamically import after mocks are applied
+    ({ auth } = await import('@/lib/auth/providers'));
+  });
+
+  it('should switch to the first available organization when user has other organizations', async () => {
+    const userId = 'user_123';
+    const mockOrgs = [
+      { id: 'org_1', slug: 'org-1', name: 'Organization 1' },
+      { id: 'org_2', slug: 'org-2', name: 'Organization 2' },
+    ];
+
+    auth.api.listOrganizations.mockResolvedValue(mockOrgs);
+    auth.api.setActiveOrganization.mockResolvedValue({});
+
+    await switchToNextOrganization(userId);
+
+    expect(auth.api.listOrganizations).toHaveBeenCalledWith({
+      query: { userId },
+      headers: mockHeaders,
+    });
+
+    expect(auth.api.setActiveOrganization).toHaveBeenCalledWith({
+      body: {
+        organizationId: 'org_1',
+        organizationSlug: 'org-1',
+      },
+      headers: mockHeaders,
+    });
+  });
+
+  it('should set active organization to null when user has no other organizations', async () => {
+    const userId = 'user_123';
+
+    auth.api.listOrganizations.mockResolvedValue([]);
+    auth.api.setActiveOrganization.mockResolvedValue({});
+
+    await switchToNextOrganization(userId);
+
+    expect(auth.api.listOrganizations).toHaveBeenCalledWith({
+      query: { userId },
+      headers: mockHeaders,
+    });
+
+    expect(auth.api.setActiveOrganization).toHaveBeenCalledWith({
+      body: {
+        organizationId: null,
+      },
+      headers: mockHeaders,
+    });
+  });
+
+  it('should handle single organization correctly', async () => {
+    const userId = 'user_123';
+    const mockOrgs = [{ id: 'org_1', slug: 'org-1', name: 'Organization 1' }];
+
+    auth.api.listOrganizations.mockResolvedValue(mockOrgs);
+    auth.api.setActiveOrganization.mockResolvedValue({});
+
+    await switchToNextOrganization(userId);
+
+    expect(auth.api.setActiveOrganization).toHaveBeenCalledWith({
+      body: {
+        organizationId: 'org_1',
+        organizationSlug: 'org-1',
+      },
+      headers: mockHeaders,
+    });
+  });
+});

--- a/app/(logged-in)/org/[slug]/settings/components/org-general-form.tsx
+++ b/app/(logged-in)/org/[slug]/settings/components/org-general-form.tsx
@@ -5,19 +5,32 @@
 
 'use client';
 
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Loader2 } from 'lucide-react';
+import { AlertTriangle, Loader2, Trash } from 'lucide-react';
 import { z } from 'zod';
 
 import { orgGeneralFormSchema } from '@/lib/trpc/schemas/organizations';
-import type { FullOrganizationResponse as Organization } from '@/lib/types/organization';
+import { ORG_ROLES, type FullOrganizationResponse as Organization } from '@/lib/types/organization';
 
+import { useDeleteOrganization } from '@/hooks/use-delete-organization';
+import { useOrganization } from '@/hooks/use-organization';
 import { useUpdateOrganization } from '@/hooks/use-update-organization';
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
-import { CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Form,
   FormControl,
@@ -33,6 +46,9 @@ type OrgFormValues = z.infer<typeof orgGeneralFormSchema>;
 
 export function OrgGeneralForm({ organization }: { organization: Organization }) {
   const { updateOrganization, isUpdating } = useUpdateOrganization();
+  const { deleteOrganization, isDeleting } = useDeleteOrganization();
+  const { currentUserRole } = useOrganization();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const form = useForm<OrgFormValues>({
     resolver: zodResolver(orgGeneralFormSchema),
@@ -48,46 +64,100 @@ export function OrgGeneralForm({ organization }: { organization: Organization })
   };
 
   const hasChanges = form.watch('name') !== organization?.name;
+  const isOwner = currentUserRole === ORG_ROLES.OWNER;
+
+  const handleDelete = () => {
+    if (!organization) return;
+    deleteOrganization({ organizationId: organization.id });
+  };
 
   if (!organization) return null;
 
   return (
     <>
-      <CardHeader>
-        <CardTitle>Organization Details</CardTitle>
-        <CardDescription>Update your organization&apos;s information</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Organization Name</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Acme Inc." {...field} disabled={isUpdating} />
-                  </FormControl>
-                  <FormDescription>This is your organization&apos;s visible name.</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+      <Card>
+        <CardHeader>
+          <CardTitle>Organization Details</CardTitle>
+          <CardDescription>Update your organization&apos;s information</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Organization Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Acme Inc." {...field} disabled={isUpdating} />
+                    </FormControl>
+                    <FormDescription>
+                      This is your organization&apos;s visible name.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-            <Button type="submit" disabled={isUpdating || !hasChanges}>
-              {isUpdating ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                'Save Changes'
-              )}
+              <Button type="submit" disabled={isUpdating || !hasChanges}>
+                {isUpdating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  'Save Changes'
+                )}
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      {isOwner && (
+        <Card className="border-destructive/20">
+          <CardHeader>
+            <CardTitle className="text-destructive">Danger Zone</CardTitle>
+            <CardDescription>
+              Permanently delete this organization and all associated data. This action cannot be
+              undone.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)}>
+              <Trash />
+              Delete Organization
             </Button>
-          </form>
-        </Form>
-      </CardContent>
+          </CardContent>
+        </Card>
+      )}
+
+      <AlertDialog open={deleteDialogOpen || isDeleting} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="text-destructive h-5 w-5" />
+              <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            </div>
+            <AlertDialogDescription>
+              This will permanently delete the organization &quot;{organization.name}&quot; and all
+              associated data. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white"
+            >
+              {isDeleting && <Loader2 className="animate-spin" />}
+              Delete organization
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/app/(logged-in)/org/[slug]/settings/components/org-member-list.tsx
+++ b/app/(logged-in)/org/[slug]/settings/components/org-member-list.tsx
@@ -370,7 +370,7 @@ export function OrgMemberList() {
             <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmRemove}
-              className="bg-destructive text-destructive-foreground"
+              className="bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white"
               disabled={isRemoving}
             >
               {isRemoving && <Loader2 className="h-4 w-4 animate-spin" />}
@@ -403,7 +403,7 @@ export function OrgMemberList() {
             {currentUserRole !== ORG_ROLES.OWNER && (
               <AlertDialogAction
                 onClick={confirmLeave}
-                className="bg-destructive text-destructive-foreground"
+                className="bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white"
                 disabled={isLeavingMutation}
               >
                 {isLeavingMutation && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/app/(logged-in)/org/[slug]/settings/page.tsx
+++ b/app/(logged-in)/org/[slug]/settings/page.tsx
@@ -56,9 +56,7 @@ export default function OrgGeneralSettingsPage() {
         <OrgLogoUpload organization={organization} />
       </Card>
 
-      <Card>
-        <OrgGeneralForm organization={organization} />
-      </Card>
+      <OrgGeneralForm organization={organization} />
     </div>
   );
 }

--- a/app/(logged-in)/settings/security/page.tsx
+++ b/app/(logged-in)/settings/security/page.tsx
@@ -98,19 +98,14 @@ export default function SecurityPage() {
         <CardHeader>
           <CardTitle className="text-destructive">Danger Zone</CardTitle>
           <CardDescription>
-            Permanently delete your account and all associated data.
+            Permanently delete your account and all associated data. This action cannot be undone.
           </CardDescription>
         </CardHeader>
         <CardContent>
           {!showDeleteConfirm ? (
-            <div className="space-y-4">
-              <p className="text-muted-foreground text-sm">
-                Once you delete your account, there is no going back. This action cannot be undone.
-              </p>
-              <Button variant="destructive" onClick={() => setShowDeleteConfirm(true)}>
-                Delete Account
-              </Button>
-            </div>
+            <Button variant="destructive" onClick={() => setShowDeleteConfirm(true)}>
+              Delete Account
+            </Button>
           ) : (
             <form onSubmit={handleDeleteAccount} className="space-y-6">
               <div className="bg-destructive/10 flex items-start gap-3 rounded-md p-4">

--- a/app/(logged-out)/onboarding/page.tsx
+++ b/app/(logged-out)/onboarding/page.tsx
@@ -49,7 +49,7 @@ export default function OnboardingPage() {
 
   const onSubmit = (data: OrganizationFormValues) => {
     createOrganization(data, {
-      onSuccess: async (slug) => {
+      onSuccess: (slug) => {
         router.push(`/org/${slug}/dashboard`);
       },
     });
@@ -96,7 +96,7 @@ export default function OnboardingPage() {
               <Button type="submit" className="w-full" disabled={isSubmitting}>
                 {isSubmitting ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 className="animate-spin" />
                     Creating workspace...
                   </>
                 ) : (

--- a/hooks/use-delete-organization.ts
+++ b/hooks/use-delete-organization.ts
@@ -1,0 +1,45 @@
+/**
+ * Delete Organization Hook
+ * Hook for deleting an organization (owner only)
+ */
+
+'use client';
+
+import { AUTH_ROUTES } from '@/lib/auth/constants';
+import { trpc } from '@/lib/trpc/client';
+
+import { useToast } from '@/hooks/use-toast';
+
+export function useDeleteOrganization() {
+  const { toast } = useToast();
+  const utils = trpc.useUtils();
+
+  const deleteMutation = trpc.organizations.deleteOrganization.useMutation({
+    onSuccess: (data) => {
+      toast({
+        title: 'Success',
+        description: data.message,
+      });
+
+      utils.organizations.getUserOrganizations.invalidate();
+      utils.organizations.getOrganization.invalidate();
+
+      // Redirect to root - middleware will handle redirects
+      setTimeout(() => {
+        window.location.href = AUTH_ROUTES.ROOT;
+      }, 500);
+    },
+    onError: (error) => {
+      toast({
+        title: 'Error',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  return {
+    deleteOrganization: deleteMutation.mutate,
+    isDeleting: deleteMutation.isPending,
+  };
+}

--- a/lib/organizations/index.ts
+++ b/lib/organizations/index.ts
@@ -4,4 +4,4 @@
  */
 
 // Utility functions
-export { generateUniqueOrgSlug, getOrgById } from './utils';
+export { generateUniqueOrgSlug, getOrgById, switchToNextOrganization } from './utils';

--- a/lib/trpc/schemas/organizations.ts
+++ b/lib/trpc/schemas/organizations.ts
@@ -87,6 +87,10 @@ export const leaveOrganizationSchema = z.object({
   organizationId: z.uuid('Invalid organization ID'),
 });
 
+export const deleteOrganizationSchema = z.object({
+  organizationId: z.uuid('Invalid organization ID'),
+});
+
 export const getOrgMembersSchema = z.object({
   organizationId: z.uuid('Invalid organization ID'),
   limit: z.number().int().positive().default(100),


### PR DESCRIPTION
## What's Changed

Add option for owners to delete an organisation. They will be redirected to another org they belong to or to /onboarding if no orgs exist

https://jam.dev/c/afdd5a8d-19bb-4d14-9e35-29b801d231c7

## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [ ] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
