### PR TITLE
Add env variable for cookie prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,4 @@ S3_SECRET_ACCESS_KEY=your_secret_key
 # Cookies
 COOKIE_SAME_SITE=lax # "none" when running the template inside an iframe
 COOKIE_SECURE=true # false on localhost
+COOKIE_PREFIX=better-auth

--- a/kosuke.config.json
+++ b/kosuke.config.json
@@ -27,6 +27,7 @@
       "BETTER_AUTH_SECRET": "mysecret",
       "COOKIE_SECURE": "true",
       "COOKIE_SAME_SITE": "none",
+      "COOKIE_PREFIX": "__KSK__COOKIE_PREFIX",
       "RESEND_API_KEY": "__KSK__RESEND_API_KEY",
       "RESEND_FROM_EMAIL": "noreply@kosuke.ai",
       "RESEND_FROM_NAME": "Kosuke Template",

--- a/lib/auth/providers/index.ts
+++ b/lib/auth/providers/index.ts
@@ -16,7 +16,7 @@ import { sendOTPEmail } from '@/lib/email/otp';
 import { redis } from '@/lib/redis';
 
 import { TEST_OTP } from '../constants';
-import { COOKIE_SAME_SITE, COOKIE_SECURE, isTestEmail } from '../utils';
+import { COOKIE_PREFIX, COOKIE_SAME_SITE, COOKIE_SECURE, isTestEmail } from '../utils';
 
 /**
  * Better Auth instance with Email OTP
@@ -68,6 +68,7 @@ export const auth = betterAuth({
       secure: COOKIE_SECURE,
       sameSite: COOKIE_SAME_SITE,
     },
+    cookiePrefix: COOKIE_PREFIX,
     database: {
       generateId: () => crypto.randomUUID(),
     },

--- a/lib/auth/utils.ts
+++ b/lib/auth/utils.ts
@@ -39,6 +39,7 @@ const SIGN_IN_ATTEMPT_EXPIRY_MINUTES = 10; // 10 minutes to complete sign-in flo
 
 export const COOKIE_SECURE = process.env.COOKIE_SECURE === 'true';
 export const COOKIE_SAME_SITE = (process.env.COOKIE_SAME_SITE ?? 'lax') as CookieSameSiteType;
+export const COOKIE_PREFIX = process.env.COOKIE_PREFIX ?? 'better-auth'; // default to better-auth as it's the default prefix used by Better Auth
 
 /**
  * Create a new sign-in attempt and store it in a secure cookie
@@ -91,7 +92,7 @@ export const isTestEmail = (email: string) => {
 // Better Auth prefixes cookies with __Secure- based on NODE_ENV or isSecure property, which doesn't work in our preview environment
 export const getSessionFromCookie = (req: NextRequest): Session | null => {
   try {
-    const cookieName = 'better-auth.session_data';
+    const cookieName = `${COOKIE_PREFIX}.session_data`;
     const cookie = req.cookies.get(cookieName) ?? req.cookies.get(`__Secure-${cookieName}`) ?? null;
 
     if (!cookie) return null;


### PR DESCRIPTION
## What's Changed

<!-- Brief description of your changes -->
Add prefix for auth cookie in template. In Core, we can use the projectId as prefix so each project has it's own authentication.

## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [ ] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
