### PR TITLE
Allow download of documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ next-env.d.ts
 
 # uploads (user files)
 /public/uploads/*
+uploads/*
 !/public/uploads/.gitkeep
 .env.cli
 

--- a/__tests__/lib/storage.test.ts
+++ b/__tests__/lib/storage.test.ts
@@ -1,0 +1,225 @@
+import { mkdir, unlink, writeFile } from 'fs/promises';
+import path from 'path';
+
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getKeyFromPathname } from '@/lib/storage';
+
+vi.mock('fs/promises');
+vi.mock('@aws-sdk/client-s3');
+vi.mock('@aws-sdk/s3-request-presigner');
+
+describe('Storage', () => {
+  let storage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const mockSend = vi.fn().mockResolvedValue({});
+
+  vi.mocked(S3Client).mockImplementation(
+    () =>
+      ({
+        send: mockSend,
+      }) as unknown as S3Client
+  );
+
+  // Helper to create a mock File with working arrayBuffer()
+  function createMockFile(content: string, filename: string, options: FilePropertyBag = {}) {
+    const blob = new Blob([content], { type: options.type });
+    const file = new File([blob], filename, options);
+
+    // Ensure arrayBuffer() is available and working
+    if (!file.arrayBuffer) {
+      Object.defineProperty(file, 'arrayBuffer', {
+        value: async () => {
+          const buffer = new ArrayBuffer(content.length);
+          const view = new Uint8Array(buffer);
+          for (let i = 0; i < content.length; i++) {
+            view[i] = content.charCodeAt(i);
+          }
+          return buffer;
+        },
+      });
+    }
+
+    return file;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    // Dynamically import storage module to get fresh instance (resets singleton)
+    storage = await import('@/lib/storage');
+  });
+
+  describe('getPresignedDownloadUrl', () => {
+    it('should generate presigned URL for S3 in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ACCESS_KEY_ID', 'test-key');
+      vi.stubEnv('S3_SECRET_ACCESS_KEY', 'test-secret');
+      vi.stubEnv('S3_REGION', 'us-east-1');
+
+      const mockUrl = 'https://s3.amazonaws.com/test-bucket/file.pdf?signed=true';
+      vi.mocked(getSignedUrl).mockResolvedValue(mockUrl);
+
+      const url = await storage.getPresignedDownloadUrl('documents/org-1/file.pdf', 300);
+      console.log(url);
+      expect(url).toBe(mockUrl);
+      expect(getSignedUrl).toHaveBeenCalledWith(expect.any(Object), expect.any(GetObjectCommand), {
+        expiresIn: 300,
+      });
+    });
+
+    it('should return local API route in development', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.stubEnv('NEXT_PUBLIC_APP_URL', 'http://localhost:3000');
+
+      const url = await storage.getPresignedDownloadUrl('documents/org-1/file.pdf');
+
+      expect(url).toBe('http://localhost:3000/api/uploads/documents/org-1/file.pdf');
+      expect(getSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it('should use default expiration time', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ACCESS_KEY_ID', 'test-key');
+      vi.stubEnv('S3_SECRET_ACCESS_KEY', 'test-secret');
+
+      vi.mocked(getSignedUrl).mockResolvedValue('https://example.com/signed');
+
+      await storage.getPresignedDownloadUrl('file.jpg');
+
+      expect(getSignedUrl).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), {
+        expiresIn: 300,
+      });
+    });
+  });
+
+  describe('uploadDocument', () => {
+    it('should upload document to S3 in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ACCESS_KEY_ID', 'test-key');
+      vi.stubEnv('S3_SECRET_ACCESS_KEY', 'test-secret');
+      vi.stubEnv('S3_ENDPOINT', 'https://s3.example.com');
+
+      const mockFile = createMockFile('test content', 'document.pdf', { type: 'application/pdf' });
+
+      const key = await storage.uploadDocument(mockFile, 'org-123');
+      expect(key).toMatch(/^documents\/org-123\/\d+-document\.pdf$/);
+      expect(mockSend).toHaveBeenCalledWith(expect.any(PutObjectCommand));
+    });
+
+    it('should upload document to local storage in development', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+
+      const mockFile = createMockFile('test content', 'report.docx', {
+        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      });
+
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(writeFile).mockResolvedValue(undefined);
+
+      const key = await storage.uploadDocument(mockFile, 'org-456');
+      expect(key).toMatch(/^documents\/org-456\/\d+-report\.docx$/);
+      expect(mkdir).toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith(expect.any(String), expect.any(Buffer));
+    });
+
+    it('should sanitize filename with special characters', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+
+      const mockFile = createMockFile('test content', 'my document (v2) #final!.pdf', {
+        type: 'application/pdf',
+      });
+
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(writeFile).mockResolvedValue(undefined);
+
+      const key = await storage.uploadDocument(mockFile, 'org-789');
+      console.log(key);
+      expect(key).toMatch('documents/org-789');
+      expect(key).toMatch(/my_document__v2___final_\.pdf$/);
+      expect(key).not.toMatch(/[()#!\s]/); // No special characters
+    });
+
+    it('should throw error on upload failure', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ACCESS_KEY_ID', 'test-key');
+      vi.stubEnv('S3_SECRET_ACCESS_KEY', 'test-secret');
+      vi.stubEnv('S3_ENDPOINT', 'https://s3.example.com');
+
+      const mockFile = createMockFile('test content', 'document.pdf', { type: 'application/pdf' });
+
+      mockSend.mockRejectedValueOnce(new Error('Upload failed'));
+
+      await expect(storage.uploadDocument(mockFile, 'org-123')).rejects.toThrow(
+        'Failed to upload document'
+      );
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('should delete document from S3 in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ACCESS_KEY_ID', 'test-key');
+      vi.stubEnv('S3_SECRET_ACCESS_KEY', 'test-secret');
+      vi.stubEnv('S3_ENDPOINT', 'https://s3.example.com');
+
+      const documentUrl =
+        'https://s3.example.com/test-bucket/documents/org-123/1234567890-file.pdf';
+      await storage.deleteDocument(documentUrl);
+
+      expect(mockSend).toHaveBeenCalledWith(expect.any(DeleteObjectCommand));
+    });
+
+    it('should delete document from local storage in development', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.mocked(unlink).mockResolvedValue(undefined);
+
+      const documentUrl = 'http://localhost:3000/uploads/documents/org-123/1234567890-file.pdf';
+      await storage.deleteDocument(documentUrl);
+
+      expect(unlink).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('uploads', 'documents', 'org-123', '1234567890-file.pdf'))
+      );
+    });
+
+    it('should handle AWS S3 document URLs', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ACCESS_KEY_ID', 'test-key');
+      vi.stubEnv('S3_SECRET_ACCESS_KEY', 'test-secret');
+
+      const documentUrl =
+        'https://test-bucket.s3.amazonaws.com/documents/org-123/1234567890-file.pdf';
+
+      await storage.deleteDocument(documentUrl);
+
+      expect(mockSend).toHaveBeenCalledWith(expect.any(DeleteObjectCommand));
+    });
+  });
+
+  describe('getKeyFromPathname', () => {
+    it('should extract S3 key from URL pathname', () => {
+      const key = getKeyFromPathname('/documents/org-123/1234567890-file.pdf');
+      expect(key).toBe('documents/org-123/1234567890-file.pdf');
+    });
+
+    it('should extract S3 key from URL pathname with bucket prefix', () => {
+      vi.stubEnv('S3_BUCKET', 'test-bucket');
+      vi.stubEnv('S3_ENDPOINT', 'https://s3.example.com');
+      const key = getKeyFromPathname('/test-bucket/documents/org-123/1234567890-file.pdf');
+      expect(key).toBe('documents/org-123/1234567890-file.pdf');
+    });
+  });
+});

--- a/app/(logged-in)/org/[slug]/documents/components/documents-columns.tsx
+++ b/app/(logged-in)/org/[slug]/documents/components/documents-columns.tsx
@@ -93,7 +93,7 @@ export function getDocumentsColumns(actions: ColumnActionsProps): ColumnDef<Docu
                   }}
                   className="text-destructive focus:text-destructive"
                 >
-                  <Trash2 className="text-destructive size-4" />
+                  <Trash2 className="text-destructive h-4 w-4" />
                   Delete
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/app/(logged-in)/org/[slug]/documents/components/documents-columns.tsx
+++ b/app/(logged-in)/org/[slug]/documents/components/documents-columns.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
-import { Loader2, MoreHorizontal, Trash2 } from 'lucide-react';
+import { Download, Loader2, MoreHorizontal, Trash2 } from 'lucide-react';
 
 import type { DocumentWithUser } from '@/lib/types';
 import { formatBytes } from '@/lib/utils';
@@ -18,10 +18,11 @@ import {
 
 interface ColumnActionsProps {
   onDelete: (id: string, displayName: string) => void;
+  onDownload: (storageUrl: string, documentId: string) => void;
 }
 
 export function getDocumentsColumns(actions: ColumnActionsProps): ColumnDef<DocumentWithUser>[] {
-  const { onDelete } = actions;
+  const { onDelete, onDownload } = actions;
   return [
     {
       id: 'name',
@@ -76,6 +77,15 @@ export function getDocumentsColumns(actions: ColumnActionsProps): ColumnDef<Docu
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDownload(doc.storageUrl, doc.id);
+                  }}
+                >
+                  <Download className="h-4 w-4" />
+                  Download
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();

--- a/app/(logged-in)/org/[slug]/documents/components/documents-data-table.tsx
+++ b/app/(logged-in)/org/[slug]/documents/components/documents-data-table.tsx
@@ -33,6 +33,7 @@ interface DocumentsDataTableProps {
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onDelete: (id: string, displayName: string) => void;
+  onDownload: (storageUrl: string, documentId: string) => void;
 }
 
 export function DocumentsDataTable({
@@ -47,8 +48,12 @@ export function DocumentsDataTable({
   onPageChange,
   onPageSizeChange,
   onDelete,
+  onDownload,
 }: DocumentsDataTableProps) {
-  const columns = useMemo(() => getDocumentsColumns({ onDelete }), [onDelete]);
+  const columns = useMemo(
+    () => getDocumentsColumns({ onDelete, onDownload }),
+    [onDelete, onDownload]
+  );
 
   // eslint-disable-next-line
   const table = useReactTable({

--- a/app/(logged-in)/org/[slug]/documents/page.tsx
+++ b/app/(logged-in)/org/[slug]/documents/page.tsx
@@ -59,6 +59,7 @@ export default function DocumentsPage() {
     totalPages,
     isLoading,
     uploadDocument,
+    downloadDocument,
     deleteDocument,
     isUploading,
     isDeleting,
@@ -85,6 +86,10 @@ export default function DocumentsPage() {
   const handleDeleteClick = (id: string, displayName: string) => {
     setDocumentToDelete({ id, displayName });
     setDeleteDialogOpen(true);
+  };
+
+  const handleDownload = async (_storageUrl: string, documentId: string) => {
+    await downloadDocument(documentId);
   };
 
   const handleDeleteConfirm = async () => {
@@ -134,6 +139,7 @@ export default function DocumentsPage() {
         onPageChange={setPage}
         onPageSizeChange={setPageSize}
         onDelete={handleDeleteClick}
+        onDownload={handleDownload}
       />
 
       <UploadDocumentDialog

--- a/app/api/uploads/[...path]/route.ts
+++ b/app/api/uploads/[...path]/route.ts
@@ -84,11 +84,12 @@ export async function GET(request: NextRequest, props: { params: Promise<{ path:
     // Determine content type from file extension using centralized constants
     const contentType = getContentTypeByExtension(filePath);
 
+    const DOWNLOAD_CACHE_MAX_AGE = 60 * 60; // 1 hour
     return new NextResponse(fileBuffer, {
       headers: {
         'Content-Type': contentType,
         'Content-Disposition': `attachment; filename="${document[0].displayName}"`,
-        'Cache-Control': 'private, max-age=3600', // Cache for 1 hour
+        'Cache-Control': `private, max-age=${DOWNLOAD_CACHE_MAX_AGE}`,
       },
     });
   } catch (error) {

--- a/app/api/uploads/[...path]/route.ts
+++ b/app/api/uploads/[...path]/route.ts
@@ -1,0 +1,98 @@
+/**
+ * Authenticated File Server for Development
+ *
+ * This route serves files from the local uploads/ directory in development only.
+ * In production, files are served directly from S3 using presigned URLs.
+ *
+ * Security:
+ * - Authenticates user via Better Auth
+ * - Verifies organization membership
+ * - Validates document exists in database
+ * - Prevents directory traversal attacks
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import { and, eq } from 'drizzle-orm';
+
+import { auth } from '@/lib/auth/providers';
+import { db } from '@/lib/db/drizzle';
+import { documents, orgMemberships } from '@/lib/db/schema';
+import { getContentTypeByExtension } from '@/lib/documents/constants';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export async function GET(request: NextRequest, props: { params: Promise<{ path: string[] }> }) {
+  try {
+    const params = await props.params;
+    const session = await auth.api.getSession({ headers: await request.headers });
+    const user = session?.user;
+
+    if (!user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Reconstruct the file path from the URL segments
+    const filePath = params.path.join('/');
+
+    // Security: Prevent directory traversal attacks
+    if (filePath.includes('..') || filePath.startsWith('/')) {
+      return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
+    }
+
+    // Extract organizationId from the path (documents/{organizationId}/...)
+    const pathParts = filePath.split('/');
+    if (pathParts[0] !== 'documents' || !pathParts[1]) {
+      return NextResponse.json({ error: 'Invalid file path' }, { status: 400 });
+    }
+
+    const organizationId = pathParts[1];
+
+    // Check if user has access to this organization
+    const membership = await db
+      .select()
+      .from(orgMemberships)
+      .where(
+        and(eq(orgMemberships.organizationId, organizationId), eq(orgMemberships.userId, user.id))
+      )
+      .limit(1);
+
+    if (membership.length === 0) {
+      return NextResponse.json(
+        { error: 'You do not have access to this organization' },
+        { status: 403 }
+      );
+    }
+
+    // Verify the document exists in the database and belongs to this organization
+    const document = await db
+      .select()
+      .from(documents)
+      .where(and(eq(documents.storageUrl, filePath), eq(documents.organizationId, organizationId)))
+      .limit(1);
+
+    if (document.length === 0) {
+      return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+
+    // Serve the file from local storage
+    const fullPath = path.join(UPLOAD_DIR, filePath);
+    const fileBuffer = await readFile(fullPath);
+
+    // Determine content type from file extension using centralized constants
+    const contentType = getContentTypeByExtension(filePath);
+
+    return new NextResponse(fileBuffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Content-Disposition': `attachment; filename="${document[0].displayName}"`,
+        'Cache-Control': 'private, max-age=3600', // Cache for 1 hour
+      },
+    });
+  } catch (error) {
+    console.error('Error serving file:', error);
+    return NextResponse.json({ error: 'File not found' }, { status: 404 });
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "kosuke-template",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.946.0",
+        "@aws-sdk/s3-request-presigner": "^3.948.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -203,6 +204,8 @@
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.936.0", "", { "dependencies": { "@aws-sdk/types": "3.936.0", "@smithy/config-resolver": "^4.4.3", "@smithy/node-config-provider": "^4.3.5", "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw=="],
 
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.948.0", "", { "dependencies": { "@aws-sdk/signature-v4-multi-region": "3.947.0", "@aws-sdk/types": "3.936.0", "@aws-sdk/util-format-url": "3.936.0", "@smithy/middleware-endpoint": "^4.3.14", "@smithy/protocol-http": "^5.3.5", "@smithy/smithy-client": "^4.9.10", "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-tlQhMDsDWwUDUzzlo8XYGpmMfjGDmXgbysv1+h1v2xJe0A+ogv/nJ6KFVP94uf1j4ePmCN/gDdxEp2PWZMBPOQ=="],
+
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.946.0", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "3.946.0", "@aws-sdk/types": "3.936.0", "@smithy/protocol-http": "^5.3.5", "@smithy/signature-v4": "^5.3.5", "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-61FZ685lKiJuQ06g6U7K3PL9EwKCxNm51wNlxyKV57nnl1GrLD0NC8O3/hDNkCQLNBArT9y3IXl2H7TtIxP8Jg=="],
 
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.946.0", "", { "dependencies": { "@aws-sdk/core": "3.946.0", "@aws-sdk/nested-clients": "3.946.0", "@aws-sdk/types": "3.936.0", "@smithy/property-provider": "^4.2.5", "@smithy/shared-ini-file-loader": "^4.4.0", "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-a5c+rM6CUPX2ExmUZ3DlbLlS5rQr4tbdoGcgBsjnAHiYx8MuMNAI+8M7wfjF13i2yvUQj5WEIddvLpayfEZj9g=="],
@@ -212,6 +215,8 @@
     "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.893.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA=="],
 
     "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.936.0", "", { "dependencies": { "@aws-sdk/types": "3.936.0", "@smithy/types": "^4.9.0", "@smithy/url-parser": "^4.2.5", "@smithy/util-endpoints": "^3.2.5", "tslib": "^2.6.2" } }, "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w=="],
+
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.936.0", "", { "dependencies": { "@aws-sdk/types": "3.936.0", "@smithy/querystring-builder": "^4.2.5", "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.893.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg=="],
 
@@ -3165,6 +3170,8 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.947.0", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "3.947.0", "@aws-sdk/types": "3.936.0", "@smithy/protocol-http": "^5.3.5", "@smithy/signature-v4": "^5.3.5", "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-UaYmzoxf9q3mabIA2hc4T6x5YSFUG2BpNjAZ207EA1bnQMiK+d6vZvb83t7dIWL/U1de1sGV19c1C81Jf14rrA=="],
+
     "@babel/core/@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
 
     "@babel/core/@babel/traverse": ["@babel/traverse@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/types": "^7.28.4", "debug": "^4.3.1" } }, "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ=="],
@@ -3542,6 +3549,8 @@
     "@aws-crypto/util/@aws-sdk/types/@smithy/types": ["@smithy/types@4.8.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-N0Zn0OT1zc+NA+UVfkYqQzviRh5ucWwO7mBV3TmHHprMnfcJNfhlPicDkBHi0ewbh+y3evR6cNAW0Raxvb01NA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.947.0", "", { "dependencies": { "@aws-sdk/core": "3.947.0", "@aws-sdk/types": "3.936.0", "@aws-sdk/util-arn-parser": "3.893.0", "@smithy/core": "^3.18.7", "@smithy/node-config-provider": "^4.3.5", "@smithy/protocol-http": "^5.3.5", "@smithy/signature-v4": "^5.3.5", "@smithy/smithy-client": "^4.9.10", "@smithy/types": "^4.9.0", "@smithy/util-config-provider": "^4.2.0", "@smithy/util-middleware": "^4.2.5", "@smithy/util-stream": "^4.5.6", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-DS2tm5YBKhPW2PthrRBDr6eufChbwXe0NjtTZcYDfUCXf0OR+W6cIqyKguwHMJ+IyYdey30AfVw9/Lb5KB8U8A=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
 
@@ -3982,6 +3991,8 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-sdk/s3-request-presigner/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/core": ["@aws-sdk/core@3.947.0", "", { "dependencies": { "@aws-sdk/types": "3.936.0", "@aws-sdk/xml-builder": "3.930.0", "@smithy/core": "^3.18.7", "@smithy/node-config-provider": "^4.3.5", "@smithy/property-provider": "^4.2.5", "@smithy/protocol-http": "^5.3.5", "@smithy/signature-v4": "^5.3.5", "@smithy/smithy-client": "^4.9.10", "@smithy/types": "^4.9.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-middleware": "^4.2.5", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw=="],
 
     "@react-email/preview-server/next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/hooks/use-documents.ts
+++ b/hooks/use-documents.ts
@@ -6,6 +6,7 @@ import type { inferRouterInputs } from '@trpc/server';
 
 import { trpc } from '@/lib/trpc/client';
 import type { AppRouter } from '@/lib/trpc/router';
+import { downloadFromUrl } from '@/lib/utils';
 
 import { useToast } from '@/hooks/use-toast';
 
@@ -119,6 +120,23 @@ export function useDocuments(options: DocumentsListQueryParams) {
     });
   };
 
+  const downloadDocument = async (documentId: string) => {
+    try {
+      const result = await utils.documents.getDownloadUrl.fetch({
+        id: documentId,
+        organizationId: options.organizationId,
+      });
+
+      downloadFromUrl(result.url, result.displayName);
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Failed to download document',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return {
     documents: data?.documents ?? [],
     total: data?.total ?? 0,
@@ -129,6 +147,7 @@ export function useDocuments(options: DocumentsListQueryParams) {
     error,
     refetch,
     uploadDocument,
+    downloadDocument,
     deleteDocument: deleteMutation.mutate,
     isUploading: uploadMutation.isPending,
     isDeleting: deleteMutation.isPending,

--- a/lib/documents/constants.ts
+++ b/lib/documents/constants.ts
@@ -203,3 +203,70 @@ const TEXT_MIME_TYPES = [
 export const SUPPORTED_MIME_TYPES = [...APPLICATION_MIME_TYPES, ...TEXT_MIME_TYPES] as const;
 
 export type SupportedMimeType = (typeof SUPPORTED_MIME_TYPES)[number];
+
+/**
+ * Maps file extensions to their corresponding MIME types
+ * Based on Google Gemini File Search API supported formats
+ */
+const EXTENSION_TO_MIME_TYPE: Record<string, string> = {
+  // Application types
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.odt': 'application/vnd.oasis.opendocument.text',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.zip': 'application/zip',
+  '.sql': 'application/sql',
+  '.tex': 'application/x-latex',
+  '.php': 'application/x-php',
+  '.sh': 'application/x-sh',
+  '.dart': 'application/dart',
+
+  // Text types - Common programming languages
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.jsx': 'text/jsx',
+  '.ts': 'text/typescript',
+  '.tsx': 'text/tsx',
+  '.csv': 'text/csv',
+  '.tsv': 'text/tab-separated-values',
+  '.rtf': 'text/rtf',
+  '.yaml': 'text/yaml',
+  '.yml': 'text/yaml',
+
+  // Programming languages
+  '.py': 'text/x-python',
+  '.java': 'text/x-java',
+  '.c': 'text/x-c',
+  '.cpp': 'text/x-c++src',
+  '.h': 'text/x-chdr',
+  '.hpp': 'text/x-c++hdr',
+  '.cs': 'text/x-csharp',
+  '.go': 'text/x-go',
+  '.rs': 'text/x-rust',
+  '.rb': 'text/x-ruby-script',
+  '.swift': 'text/x-swift',
+  '.kt': 'text/x-kotlin',
+  '.scala': 'text/x-scala',
+  '.r': 'text/x-r-markdown',
+};
+
+/**
+ * Gets the MIME type for a file based on its extension
+ * Returns 'application/octet-stream' for unknown file types
+ */
+export function getContentTypeByExtension(filePath: string): string {
+  const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
+  return EXTENSION_TO_MIME_TYPE[ext] || 'application/octet-stream';
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -264,8 +264,14 @@ export async function deleteDocument(documentUrl: string): Promise<void> {
 
       await s3.send(command);
     } else if (documentUrl.includes('/uploads/')) {
+      const parts = documentUrl.split('/uploads/');
+      if (parts.length < 2) {
+        console.error('Invalid upload URL format');
+        return;
+      }
+
       // Delete from local file system
-      const relativePath = documentUrl.split('/uploads/')[1];
+      const relativePath = parts[1];
       const filePath = path.join(UPLOAD_DIR, relativePath);
       await unlink(filePath);
     }

--- a/lib/trpc/schemas/documents.ts
+++ b/lib/trpc/schemas/documents.ts
@@ -37,6 +37,11 @@ export const deleteDocumentSchema = z.object({
   organizationId: z.uuid(),
 });
 
+export const getDownloadUrlSchema = z.object({
+  id: z.uuid(),
+  organizationId: z.uuid(),
+});
+
 // Chat schemas
 export const createChatSessionSchema = z.object({
   organizationId: z.uuid(),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,13 +63,21 @@ export function downloadFile(data: string, filename: string, mimeType?: string) 
     blob = new Blob([data], { type: mimeType || 'text/csv;charset=utf-8;' });
   }
 
-  const link = document.createElement('a');
   const url = URL.createObjectURL(blob);
-  link.setAttribute('href', url);
-  link.setAttribute('download', filename);
-  link.style.visibility = 'hidden';
+  downloadFromUrl(url, filename);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Downloads a file from a URL (S3 presigned URL or API route)
+ * Used for downloading documents, images, etc.
+ */
+export function downloadFromUrl(url: string, filename: string) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.target = '_blank'; // Fallback: open in new tab if download fails
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.946.0",
+    "@aws-sdk/s3-request-presigner": "^3.948.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
## What's Changed

<!-- Brief description of your changes -->

Allow user to download documents both from the chat and the documents list
- Locally, files are saved under /uploads. 
- On prod the user can download them from a presigned s3 url.

https://jam.dev/c/54f4dcd3-d9e9-4207-b00c-f6e35fa6af19

## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [ ] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
