### PR TITLE
Add API key management feature

### DIFF
--- a/__tests__/lib/billing/operations.test.ts
+++ b/__tests__/lib/billing/operations.test.ts
@@ -31,8 +31,8 @@ vi.mock('@/lib/db', () => ({
   },
 }));
 
-vi.mock('@/lib/billing/client', () => ({
-  stripe: {
+vi.mock('@/lib/billing/client', () => {
+  const stripe = {
     customers: {
       create: vi.fn(),
     },
@@ -54,8 +54,12 @@ vi.mock('@/lib/billing/client', () => ({
       list: vi.fn(),
       cancel: vi.fn(),
     },
-  },
-}));
+  };
+  return {
+    getStripe: vi.fn().mockResolvedValue(stripe),
+    stripe: stripe,
+  };
+});
 
 vi.mock('@/lib/billing/subscription', () => ({
   getOrgSubscription: vi.fn(),

--- a/__tests__/lib/billing/stripe-sync.test.ts
+++ b/__tests__/lib/billing/stripe-sync.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { stripe } from '@/lib/billing/client';
+import { getStripe } from '@/lib/billing/client';
 import { syncOrgSubscriptionFromStripe, syncStaleSubscriptions } from '@/lib/billing/stripe-sync';
 import { db } from '@/lib/db';
 import { SubscriptionStatus, SubscriptionTier } from '@/lib/db/schema';
@@ -24,17 +24,24 @@ vi.mock('@/lib/db', () => ({
 }));
 
 // Mock Stripe client
-vi.mock('@/lib/billing/client', () => ({
-  stripe: {
+vi.mock('@/lib/billing/client', () => {
+  const stripe = {
     subscriptions: {
       retrieve: vi.fn(),
     },
-  },
-}));
+  };
+  return {
+    getStripe: vi.fn().mockResolvedValue(stripe),
+    stripe: stripe,
+  };
+});
 
 describe('Stripe Sync Module', () => {
-  beforeEach(() => {
+  let stripe: any;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
+    stripe = await getStripe();
   });
 
   describe('syncOrgSubscriptionFromStripe', () => {

--- a/__tests__/lib/services/organization-service.test.ts
+++ b/__tests__/lib/services/organization-service.test.ts
@@ -17,7 +17,6 @@ import {
   getOrganizationById,
   getOrganizationBySlug,
   getUserOrganizations,
-  isGoogleApiKeyConfigured,
   updateOrganization,
   uploadOrganizationLogo,
 } from '@/lib/services/organization-service';
@@ -484,24 +483,6 @@ describe('Organization Service', () => {
       );
 
       expect(deleteProfileImage).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('isGoogleApiKeyConfigured', () => {
-    it('should return true when API key is configured', () => {
-      vi.stubEnv('GOOGLE_AI_API_KEY', 'test-key');
-
-      const result = isGoogleApiKeyConfigured();
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false when API key is not configured', () => {
-      vi.stubEnv('GOOGLE_AI_API_KEY', '');
-
-      const result = isGoogleApiKeyConfigured();
-
-      expect(result).toBe(false);
     });
   });
 });

--- a/app/(logged-in)/settings/billing/page.tsx
+++ b/app/(logged-in)/settings/billing/page.tsx
@@ -11,6 +11,7 @@ import { useSubscriptionActions } from '@/hooks/use-subscription-actions';
 import {
   useCanSubscribe,
   usePricingData,
+  useStripeConfigured,
   useSubscriptionStatus,
 } from '@/hooks/use-subscription-data';
 import { useToast } from '@/hooks/use-toast';
@@ -143,10 +144,11 @@ export default function BillingPage() {
   const { user } = useUser();
   const { toast } = useToast();
   const { currentUserRole } = useOrganization();
+  const { data: stripeConfig, isLoading: isLoadingConfig } = useStripeConfigured();
   const { data: subscriptionInfo, isLoading: isLoadingStatus } = useSubscriptionStatus();
   const { data: eligibility, isLoading: isLoadingEligibility } = useCanSubscribe();
   const { data: pricingData, isLoading: isLoadingPricing } = usePricingData();
-  const isLoading = isLoadingStatus || isLoadingEligibility || isLoadingPricing;
+  const isLoading = isLoadingConfig || isLoadingStatus || isLoadingEligibility || isLoadingPricing;
 
   // Check if user is owner (can manage billing)
   const isOwner = currentUserRole === ORG_ROLES.OWNER;
@@ -217,6 +219,18 @@ export default function BillingPage() {
   }
 
   // Handle case when Stripe is not configured
+  if (!stripeConfig?.isConfigured) {
+    return (
+      <div className="py-6">
+        <ErrorMessage
+          title="Stripe API Key Not Configured"
+          description="Billing features are not available. Please configure your STRIPE_SECRET_KEY environment variable to enable subscription management."
+        />
+      </div>
+    );
+  }
+
+  // Handle case when pricing data couldn't be loaded
   if (!pricingData || Object.keys(pricingData).length === 0) {
     return (
       <div className="py-6">

--- a/app/admin/components/admin-sidebar.tsx
+++ b/app/admin/components/admin-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Building2,
   Database,
   FileText,
+  KeySquare,
   LayoutDashboard,
   Settings,
   Shield,
@@ -69,6 +70,18 @@ export function AdminSidebar({ ...props }: React.ComponentProps<typeof Sidebar>)
       title: 'LLM Logs',
       url: '/admin/llm-logs',
       icon: FileText,
+    },
+    {
+      title: 'Configuration',
+      url: '/admin/system/apikeys',
+      icon: Settings,
+      items: [
+        {
+          title: 'API Keys',
+          url: '/admin/system/apikeys',
+          icon: KeySquare,
+        },
+      ],
     },
   ];
 

--- a/app/admin/system/apikeys/page.tsx
+++ b/app/admin/system/apikeys/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { ApiKeysConfigForm } from '@/components/apikeys-config-form';
+
+export default function AdminAPIKeysConfigPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">API Keys</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Manage system-wide API keys for your application.
+        </p>
+      </div>
+
+      <ApiKeysConfigForm />
+    </div>
+  );
+}

--- a/components/apikeys-config-form.tsx
+++ b/components/apikeys-config-form.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Eye, EyeOff, Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+
+import { CONFIG_KEYS, type ConfigKey } from '@/lib/services/constants';
+import { trpc } from '@/lib/trpc/client';
+
+import { useToast } from '@/hooks/use-toast';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+
+interface EditingState {
+  key: ConfigKey;
+  value: string;
+  showValue: boolean;
+}
+
+/**
+ * System configuration form for managing system-wide secrets
+ * Only accessible to superadmins
+ */
+export function ApiKeysConfigForm() {
+  const { toast } = useToast();
+  const utils = trpc.useUtils();
+
+  const [editingConfig, setEditingConfig] = useState<EditingState | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [configToDelete, setConfigToDelete] = useState<ConfigKey | null>(null);
+
+  // Fetch config status for all keys
+  const { data: configStatus, isLoading } = trpc.admin.config.list.useQuery(undefined, {
+    staleTime: 1000 * 60 * 2, // 2 minutes
+  });
+
+  // Mutations
+  const setConfigMutation = trpc.admin.config.set.useMutation({
+    onSuccess: (_, variables) => {
+      toast({
+        title: 'Success',
+        description: `Configuration ${variables.key} updated successfully`,
+      });
+      utils.admin.config.list.invalidate();
+      setEditingConfig(null);
+    },
+    onError: (error) => {
+      toast({
+        title: 'Error',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const deleteConfigMutation = trpc.admin.config.delete.useMutation({
+    onSuccess: () => {
+      toast({
+        title: 'Success',
+        description: 'Configuration deleted successfully',
+      });
+      utils.admin.config.list.invalidate();
+      setDeleteDialogOpen(false);
+      setConfigToDelete(null);
+    },
+    onError: (error) => {
+      toast({
+        title: 'Error',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleEditClick = (key: ConfigKey) => {
+    setEditingConfig({
+      key,
+      value: '',
+      showValue: false,
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingConfig(null);
+  };
+
+  const handleSave = async () => {
+    if (!editingConfig || !editingConfig.value.trim()) {
+      toast({
+        title: 'Error',
+        description: 'Value cannot be empty',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    await setConfigMutation.mutateAsync({
+      key: editingConfig.key,
+      value: editingConfig.value,
+    });
+  };
+
+  const handleDeleteClick = (key: ConfigKey) => {
+    setConfigToDelete(key);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!configToDelete) return;
+    await deleteConfigMutation.mutateAsync({ key: configToDelete });
+  };
+
+  const toggleShowValue = () => {
+    if (!editingConfig) return;
+    setEditingConfig({
+      ...editingConfig,
+      showValue: !editingConfig.showValue,
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center">
+        <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!configStatus) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Failed to load configuration status. Please try again later.
+      </p>
+    );
+  }
+
+  const mapKeysReadableNames: Record<ConfigKey, string> = {
+    STRIPE_SECRET_KEY: 'Stripe API Key',
+    STRIPE_PUBLISHABLE_KEY: 'Stripe Public Key',
+    STRIPE_WEBHOOK_SECRET: 'Stripe Webhook Secret',
+    GOOGLE_AI_API_KEY: 'Google API Key',
+  };
+
+  return (
+    <>
+      <Card className="max-w-3xl">
+        <CardContent className="space-y-6">
+          {Object.values(CONFIG_KEYS).map((key) => {
+            const status = configStatus[key];
+            const isEditing = editingConfig?.key === key;
+            const isPending =
+              setConfigMutation.isPending && setConfigMutation.variables?.key === key;
+
+            return (
+              <div key={key} className="space-y-2">
+                <h3 className="text-sm font-medium">{mapKeysReadableNames[key]}</h3>
+
+                <div className="flex items-center gap-2">
+                  {isEditing ? (
+                    <>
+                      <div className="relative flex-1">
+                        <Input
+                          type={editingConfig.showValue ? 'text' : 'password'}
+                          value={editingConfig.value}
+                          onChange={(e) =>
+                            setEditingConfig({ ...editingConfig, value: e.target.value })
+                          }
+                          placeholder={status.exists ? 'Enter new value' : 'Enter value'}
+                          disabled={isPending}
+                          className="pr-10 text-sm"
+                          autoFocus
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2 p-0"
+                          onClick={toggleShowValue}
+                          disabled={isPending}
+                        >
+                          {editingConfig.showValue ? (
+                            <EyeOff className="h-3.5 w-3.5" />
+                          ) : (
+                            <Eye className="h-3.5 w-3.5" />
+                          )}
+                        </Button>
+                      </div>
+                      <Button
+                        size="sm"
+                        onClick={handleSave}
+                        disabled={isPending || !editingConfig.value.trim()}
+                        className="text-xs"
+                      >
+                        {isPending ? (
+                          <>
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            Saving
+                          </>
+                        ) : (
+                          'Save'
+                        )}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleCancelEdit}
+                        disabled={isPending}
+                        className="text-xs"
+                      >
+                        Cancel
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <div
+                        className="min-w-0 flex-1 cursor-pointer text-sm"
+                        onDoubleClick={() => handleEditClick(key)}
+                      >
+                        {status.exists ? (
+                          status.maskedValue
+                        ) : (
+                          <span className="text-muted-foreground italic">Not configured</span>
+                        )}
+                      </div>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon" onClick={(e) => e.stopPropagation()}>
+                            <span className="sr-only">Open menu</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleEditClick(key);
+                            }}
+                          >
+                            <Pencil />
+                            Edit
+                          </DropdownMenuItem>
+                          {status.exists && (
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteClick(key);
+                              }}
+                              className="text-destructive hover:!text-destructive"
+                            >
+                              <Trash2 className="text-destructive h-4 w-4" />
+                              Delete
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {configToDelete &&
+                `This will permanently delete the configuration for "${configToDelete}". This action cannot be undone.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteConfigMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              disabled={deleteConfigMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteConfigMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/components/apikeys-config-form.tsx
+++ b/components/apikeys-config-form.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface EditingState {
   key: ConfigKey;
@@ -103,7 +104,8 @@ export function ApiKeysConfigForm() {
   };
 
   const handleSave = async () => {
-    if (!editingConfig || !editingConfig.value.trim()) {
+    const trimmedValue = editingConfig?.value.trim();
+    if (!editingConfig || !trimmedValue) {
       toast({
         title: 'Error',
         description: 'Value cannot be empty',
@@ -114,7 +116,7 @@ export function ApiKeysConfigForm() {
 
     await setConfigMutation.mutateAsync({
       key: editingConfig.key,
-      value: editingConfig.value,
+      value: trimmedValue,
     });
   };
 
@@ -138,9 +140,19 @@ export function ApiKeysConfigForm() {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center">
-        <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
-      </div>
+      <Card className="max-w-3xl">
+        <CardContent className="space-y-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-10 flex-1" />
+                <Skeleton className="h-10 w-10" />
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
     );
   }
 

--- a/hooks/use-google-api-key.ts
+++ b/hooks/use-google-api-key.ts
@@ -5,7 +5,9 @@ import { trpc } from '@/lib/trpc/client';
  * Used to gate AI features (Documents, Assistant) when key is missing
  */
 export function useGoogleApiKey() {
-  const { data, isLoading } = trpc.organizations.checkGoogleApiKey.useQuery();
+  const { data, isLoading } = trpc.organizations.checkGoogleApiKey.useQuery(undefined, {
+    refetchOnMount: 'always',
+  });
 
   return {
     isConfigured: data?.configured ?? false,

--- a/hooks/use-subscription-data.ts
+++ b/hooks/use-subscription-data.ts
@@ -5,6 +5,15 @@ import { trpc } from '@/lib/trpc/client';
 import { useAuth } from './use-auth';
 
 /**
+ * Check if Stripe API key is configured
+ */
+export function useStripeConfigured() {
+  return trpc.billing.isConfigured.useQuery(undefined, {
+    refetchOnMount: 'always',
+  });
+}
+
+/**
  * Get user's subscription status
  */
 export function useSubscriptionStatus() {

--- a/lib/ai/rag.ts
+++ b/lib/ai/rag.ts
@@ -6,24 +6,69 @@ import type {
 } from '@google/genai';
 import { GoogleGenAI } from '@google/genai';
 
-let aiClient: GoogleGenAI | null = null;
+import { getConfigOrEnv } from '@/lib/services/config-service';
+import { CONFIG_KEYS } from '@/lib/services/constants';
 
-function getClient(): GoogleGenAI {
-  if (!aiClient) {
-    const apiKey = process.env.GOOGLE_AI_API_KEY;
-    if (!apiKey) {
-      throw new Error('GOOGLE_AI_API_KEY environment variable is required');
-    }
-    aiClient = new GoogleGenAI({ apiKey });
+/**
+ * Centralized Google AI client configuration
+ * Single source of truth for all Google AI API interactions
+ *
+ * Lazy initialization - only throws error when actually used.
+ * This allows the app to run without Google AI configured.
+ * Users must provide their own GOOGLE_AI_API_KEY to enable AI features.
+ *
+ * The Google AI API key is checked in two places (priority order):
+ * 1. Database (system_config table) - for BYOK (Bring Your Own Key) pattern
+ * 2. Environment variable - fallback for traditional .env configuration
+ */
+
+let aiClient: GoogleGenAI | null = null;
+let initPromise: Promise<GoogleGenAI> | null = null;
+
+/**
+ * Get initialized Google AI client
+ * Automatically checks database and environment for API key
+ *
+ * @returns Promise<GoogleGenAI> - Initialized Google AI client
+ * @throws Error if GOOGLE_AI_API_KEY is not configured
+ *
+ * @example
+ * const client = await getClient();
+ * const store = await client.fileSearchStores.create({ config });
+ */
+async function getClient(): Promise<GoogleGenAI> {
+  if (aiClient) {
+    return aiClient;
   }
-  return aiClient;
+
+  // Cache the initialization promise to avoid duplicate DB queries
+  if (!initPromise) {
+    initPromise = (async () => {
+      const apiKey = await getConfigOrEnv(CONFIG_KEYS.GOOGLE_AI_API_KEY);
+
+      if (!apiKey) {
+        throw new Error(
+          'GOOGLE_AI_API_KEY is required. Configure it via:\n' +
+            '1. Admin panel (System → API Keys)\n' +
+            '2. Environment variable (GOOGLE_AI_API_KEY)'
+        );
+      }
+
+      aiClient = new GoogleGenAI({ apiKey });
+
+      return aiClient;
+    })();
+  }
+
+  return initPromise;
 }
 
 /**
  * Create a new File Search Store
  */
-export function createFileSearchStore(config: CreateFileSearchStoreParameters['config']) {
-  return getClient().fileSearchStores.create({ config });
+export async function createFileSearchStore(config: CreateFileSearchStoreParameters['config']) {
+  const client = await getClient();
+  return client.fileSearchStores.create({ config });
 }
 
 /**
@@ -31,7 +76,7 @@ export function createFileSearchStore(config: CreateFileSearchStoreParameters['c
  */
 export async function uploadToFileSearchStore(params: UploadToFileSearchStoreParameters) {
   const { file, fileSearchStoreName, config } = params;
-  const client = getClient();
+  const client = await getClient();
   const operation = await client.fileSearchStores.uploadToFileSearchStore({
     file,
     fileSearchStoreName,
@@ -43,8 +88,15 @@ export async function uploadToFileSearchStore(params: UploadToFileSearchStorePar
   });
 
   // Poll for completion
+  const MAX_ATTEMPTS = 60; // 60 attempts * 2 seconds = 2 minutes max
+  let attempts = 0;
   let currentOperation = operation;
+
   while (!currentOperation.done) {
+    if (++attempts > MAX_ATTEMPTS) {
+      throw new Error('File upload operation timed out after 2 minutes');
+    }
+
     await new Promise((resolve) => setTimeout(resolve, 2000));
     currentOperation = await client.operations.get({ operation: currentOperation });
   }
@@ -55,15 +107,17 @@ export async function uploadToFileSearchStore(params: UploadToFileSearchStorePar
 /**
  * Delete a File Search Store
  */
-export function deleteFileSearchStore({ name, config }: DeleteFileSearchStoreParameters) {
-  return getClient().fileSearchStores.delete({ name, config });
+export async function deleteFileSearchStore({ name, config }: DeleteFileSearchStoreParameters) {
+  const client = await getClient();
+  return client.fileSearchStores.delete({ name, config });
 }
 
 /**
  * Delete a document and its chunks from File Search Store
  */
-export function deleteDocumentFromFileSearchStore({ name }: DeleteDocumentParameters) {
-  return getClient().fileSearchStores.documents.delete({
+export async function deleteDocumentFromFileSearchStore({ name }: DeleteDocumentParameters) {
+  const client = await getClient();
+  return client.fileSearchStores.documents.delete({
     name,
     config: {
       force: true,
@@ -74,13 +128,15 @@ export function deleteDocumentFromFileSearchStore({ name }: DeleteDocumentParame
 /**
  * List all File Search Stores
  */
-export function listFileSearchStores() {
-  return getClient().fileSearchStores.list();
+export async function listFileSearchStores() {
+  const client = await getClient();
+  return client.fileSearchStores.list();
 }
 
 /**
  * List all documents in a File Search Store
  */
-export function listDocuments(fileSearchStoreName: string) {
-  return getClient().fileSearchStores.documents.list({ parent: fileSearchStoreName });
+export async function listDocuments(fileSearchStoreName: string) {
+  const client = await getClient();
+  return client.fileSearchStores.documents.list({ parent: fileSearchStoreName });
 }

--- a/lib/billing/client.ts
+++ b/lib/billing/client.ts
@@ -1,15 +1,62 @@
 import Stripe from 'stripe';
 
+import { getConfigOrEnv } from '@/lib/services/config-service';
+import { CONFIG_KEYS } from '@/lib/services/constants';
+
 /**
  * Centralized Stripe client configuration
  * Single source of truth for all Stripe API interactions
+ *
+ * Lazy initialization - only throws error when actually used.
+ * This allows the app to run without Stripe configured (free tier only).
+ * Users must provide their own STRIPE_SECRET_KEY to enable billing features.
+ *
+ * The Stripe API key is checked in two places (priority order):
+ * 1. Database (system_config table) - for BYOK (Bring Your Own Key) pattern
+ * 2. Environment variable - fallback for traditional .env configuration
  */
 
-if (!process.env.STRIPE_SECRET_KEY) {
-  throw new Error('STRIPE_SECRET_KEY is not set in environment variables');
-}
+let stripeClient: Stripe | null = null;
+let initPromise: Promise<Stripe> | null = null;
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2025-12-15.clover',
-  typescript: true,
-});
+/**
+ * Get initialized Stripe client
+ * Automatically checks database and environment for API key
+ *
+ * @returns Promise<Stripe> - Initialized Stripe client
+ * @throws Error if STRIPE_SECRET_KEY is not configured
+ *
+ * @example
+ * const stripe = await getStripe();
+ * const customer = await stripe.customers.create({ email: '...' });
+ * const event = await stripe.webhooks.constructEventAsync(...);
+ */
+export async function getStripe(): Promise<Stripe> {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  // Cache the initialization promise to avoid duplicate DB queries
+  if (!initPromise) {
+    initPromise = (async () => {
+      const apiKey = await getConfigOrEnv(CONFIG_KEYS.STRIPE_SECRET_KEY);
+
+      if (!apiKey) {
+        throw new Error(
+          'STRIPE_SECRET_KEY is required. Configure it via:\n' +
+            '1. Admin panel (System → API Keys)\n' +
+            '2. Environment variable (STRIPE_SECRET_KEY)'
+        );
+      }
+
+      stripeClient = new Stripe(apiKey, {
+        apiVersion: '2025-12-15.clover',
+        typescript: true,
+      });
+
+      return stripeClient;
+    })();
+  }
+
+  return initPromise;
+}

--- a/lib/billing/index.ts
+++ b/lib/billing/index.ts
@@ -46,7 +46,7 @@ export {
 } from './lookup-keys';
 
 // Client and types
-export { stripe } from './client';
+export { getStripe } from './client';
 export type {
   SubscriptionEligibility,
   OrgSubscriptionInfo,

--- a/lib/billing/stripe-sync.ts
+++ b/lib/billing/stripe-sync.ts
@@ -4,7 +4,7 @@ import Stripe from 'stripe';
 import { db } from '@/lib/db';
 import { orgSubscriptions } from '@/lib/db/schema';
 
-import { stripe } from './client';
+import { getStripe } from './client';
 
 /**
  * Stripe sync utilities
@@ -36,6 +36,7 @@ export async function syncOrgSubscriptionFromStripe(organizationId: string): Pro
 
     // Fetch from Stripe
     let stripeSubscription: Stripe.Subscription;
+    const stripe = await getStripe();
     try {
       stripeSubscription = await stripe.subscriptions.retrieve(
         localSubscription.stripeSubscriptionId

--- a/lib/db/scripts/db-seed.ts
+++ b/lib/db/scripts/db-seed.ts
@@ -14,7 +14,7 @@
 import { faker } from '@faker-js/faker';
 import { eq } from 'drizzle-orm';
 
-import { stripe } from '@/lib/billing/client';
+import { getStripe } from '@/lib/billing/client';
 import { withPrefix } from '@/lib/billing/lookup-keys';
 import { db } from '@/lib/db/drizzle';
 import type { NewOrder, OrderStatus } from '@/lib/types';
@@ -59,7 +59,7 @@ function calculatePeriodEnd(startDate: Date): Date {
 async function seed() {
   console.log('🌱 Starting database seed...\n');
   console.log('📌 Note: If you encounter duplicate key errors, run `bun run db:reset`');
-
+  const stripe = await getStripe();
   try {
     const janeSmithEmail = 'jane+kosuke_test@example.com';
     const johnDoeEmail = 'john+kosuke_test@example.com';

--- a/lib/services/constants.ts
+++ b/lib/services/constants.ts
@@ -1,3 +1,16 @@
+/**
+ * Configuration keys for type-safe access to system config
+ * Values match environment variable names for simplicity
+ */
+export const CONFIG_KEYS = {
+  STRIPE_WEBHOOK_SECRET: 'STRIPE_WEBHOOK_SECRET',
+  STRIPE_SECRET_KEY: 'STRIPE_SECRET_KEY',
+  STRIPE_PUBLISHABLE_KEY: 'STRIPE_PUBLISHABLE_KEY',
+  GOOGLE_AI_API_KEY: 'GOOGLE_AI_API_KEY',
+} as const;
+
+export type ConfigKey = (typeof CONFIG_KEYS)[keyof typeof CONFIG_KEYS];
+
 export const ERRORS = {
   NOT_FOUND: 'NOT_FOUND',
   BAD_REQUEST: 'BAD_REQUEST',

--- a/lib/services/member-service.ts
+++ b/lib/services/member-service.ts
@@ -5,7 +5,7 @@
 import { eq } from 'drizzle-orm';
 
 import { auth } from '@/lib/auth/providers';
-import { stripe } from '@/lib/billing/client';
+import { getStripe } from '@/lib/billing/client';
 import { getOrgSubscription } from '@/lib/billing/subscription';
 import { db } from '@/lib/db';
 import type { OrgMembership, OrgRole, Organization, User } from '@/lib/db/schema';
@@ -54,6 +54,7 @@ export async function updateMemberRole(params: {
         );
 
         // Cancel subscription in Stripe
+        const stripe = await getStripe();
         await stripe.subscriptions.update(subscription.activeSubscription.stripeSubscriptionId, {
           cancel_at_period_end: true,
         });

--- a/lib/services/organization-service.ts
+++ b/lib/services/organization-service.ts
@@ -318,12 +318,3 @@ export async function deleteOrganizationLogo(params: {
     message: 'Organization logo deleted successfully',
   };
 }
-
-/**
- * Check if Google AI API key is configured
- * Used to gate AI features (Documents, Assistant) when key is missing
- * @returns True if configured, false otherwise
- */
-export function isGoogleApiKeyConfigured(): boolean {
-  return !!process.env.GOOGLE_AI_API_KEY;
-}

--- a/lib/trpc/routers/billing.ts
+++ b/lib/trpc/routers/billing.ts
@@ -12,6 +12,7 @@ import {
   reactivateOrgSubscription,
 } from '@/lib/billing';
 import { syncOrgSubscriptionFromStripe, syncStaleSubscriptions } from '@/lib/billing/stripe-sync';
+import { isStripeApiKeyConfigured } from '@/lib/services/config-service';
 import {
   canSubscribeSchema,
   createCheckoutSchema,
@@ -32,6 +33,18 @@ import { orgOwnerProcedure, orgProcedure, protectedProcedure, router } from '../
  * Organization owner procedure - middleware that checks for owner role
  */
 export const billingRouter = router({
+  /**
+   * Check if Stripe API key is configured
+   * Returns boolean indicating if billing features are available
+   */
+  isConfigured: protectedProcedure.query(async () => {
+    const isConfigured = await isStripeApiKeyConfigured();
+
+    return {
+      isConfigured,
+    };
+  }),
+
   /**
    * Get pricing information from Stripe
    * Fetches all active prices using lookup keys

--- a/lib/trpc/routers/organizations.ts
+++ b/lib/trpc/routers/organizations.ts
@@ -4,6 +4,7 @@
  */
 import { headers } from 'next/headers';
 
+import * as configService from '@/lib/services/config-service';
 import * as invitationService from '@/lib/services/invitation-service';
 import * as memberService from '@/lib/services/member-service';
 import * as organizationService from '@/lib/services/organization-service';
@@ -249,9 +250,11 @@ export const organizationsRouter = router({
    * Check if Google AI API key is configured
    * Used to gate AI features (Documents, Assistant) when key is missing
    */
-  checkGoogleApiKey: protectedProcedure.query(() => {
+  checkGoogleApiKey: protectedProcedure.query(async () => {
+    const isConfigured = await configService.isGoogleApiKeyConfigured();
+
     return {
-      configured: organizationService.isGoogleApiKeyConfigured(),
+      configured: isConfigured,
     };
   }),
 });

--- a/lib/trpc/schemas/config.ts
+++ b/lib/trpc/schemas/config.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import { CONFIG_KEYS } from '@/lib/services/constants';
+
+export const getConfigSchema = z.object({
+  key: z.enum(Object.values(CONFIG_KEYS)),
+});
+
+export const setConfigSchema = z.object({
+  key: z.enum(Object.values(CONFIG_KEYS)),
+  value: z.string().min(1, 'Config value cannot be empty'),
+  description: z.string().optional(),
+});
+
+export const deleteConfigSchema = z.object({
+  key: z.enum(Object.values(CONFIG_KEYS)),
+});
+
+export const listConfigsSchema = z.object({}).optional();

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -37,3 +37,4 @@ process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
 process.env.BETTER_AUTH_SECRET = 'test-secret-key-for-testing-only';
 process.env.GOOGLE_AI_API_KEY = 'test-google-ai-api-key';
 process.env.RESEND_API_KEY = 'test-resend-api-key';
+process.env.ENCRYPTION_KEY = 'test-encryption-key-minimum-32-chars-long';


### PR DESCRIPTION
## What's Changed

Add functionality to allow users to bring their own API keys. Using env variables still work as a fallback, but if keys exist in the db, those will be used.

https://jam.dev/c/c1e63bcd-10fc-4e46-b091-53ac843a69c4

## Type of Change

<!-- Check all that apply -->

- [ ] 🚀 **feature** - New feature or enhancement
- [ ] 🐛 **bug** - Bug fix
- [ ] 📚 **documentation** - Documentation update
- [ ] 🔧 **enhancement** - Improvement to existing feature
- [ ] ⚡ **performance** - Performance improvement
- [ ] 🔒 **security** - Security fix
- [ ] 💥 **breaking** - Breaking change (requires migration)
- [ ] 🧹 **chore** - Maintenance or internal change

## Testing

<!-- Describe how you tested your changes -->

- [ ] Added new tests for changes (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Breaking Changes

<!-- If this is a breaking change, describe migration steps -->

## Related Issues

<!-- Link related issues: Closes #123 -->
