### PR TITLE
test: force production startup failure

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -41,6 +41,12 @@ export async function register() {
     validateEnvironmentVariables();
   }
 
+  // Temporary: force the production server to crash on startup so Kosuke can
+  // exercise the real failed-deploy path for this test project.
+  if (process.env.NEXT_RUNTIME === 'nodejs' && process.env.NODE_ENV === 'production') {
+    throw new Error('Temporary forced startup failure for production deploy testing');
+  }
+
   // Initialize Sentry in production
   if (process.env.NEXT_PUBLIC_SENTRY_DSN && process.env.NODE_ENV === 'production') {
     console.log('📊 Initializing Sentry...');


### PR DESCRIPTION
## Summary
- add a temporary production-only startup crash in instrumentation
- make the test project fail during deploy like a real application startup issue

## Verification
- bun run lint
- bun run typecheck
- verified instrumentation register() throws in production mode
